### PR TITLE
Update Whisper large URL

### DIFF
--- a/lib/src/models/whisper_model.dart
+++ b/lib/src/models/whisper_model.dart
@@ -13,7 +13,7 @@ enum WhisperModel {
   medium('medium'),
 
   /// large model for all languages
-  large('large'),
+  large('large-v3'),
 
   /// tiny model for english only
   tinyEn('tiny.en'),


### PR DESCRIPTION
The 'large' model at https://huggingface.co/ggerganov/whisper.cpp/tree/main should be named 'large-v3', otherwise the download fails