### PR TITLE
feat: live (streaming) transcription with partial results

### DIFF
--- a/android/src/whisper/main.cpp
+++ b/android/src/whisper/main.cpp
@@ -60,6 +60,8 @@ struct whisper_params
     bool split_on_word = false;
     // whisper_full_params.no_context: disable cross-segment text conditioning.
     bool no_context = false;
+    // whisper_full_params.suppress_non_speech_tokens: drop [BLANK_AUDIO]-style annotations.
+    bool suppress_nst = false;
 
     std::string language = "auto";
     std::string prompt;
@@ -99,6 +101,10 @@ json transcribe(json jsonBody) noexcept
     if (jsonBody.contains("no_context") && jsonBody["no_context"].is_boolean())
     {
         params.no_context = jsonBody["no_context"].get<bool>();
+    }
+    if (jsonBody.contains("suppress_non_speech_tokens") && jsonBody["suppress_non_speech_tokens"].is_boolean())
+    {
+        params.suppress_nst = jsonBody["suppress_non_speech_tokens"].get<bool>();
     }
     json jsonResult;
     jsonResult["@type"] = "transcribe";
@@ -201,6 +207,7 @@ json transcribe(json jsonBody) noexcept
             wparams.initial_prompt = params.prompt.c_str();
         }
         wparams.no_context = params.no_context;
+        wparams.suppress_non_speech_tokens = params.suppress_nst;
 
         if (params.split_on_word) {
             wparams.max_len = 1;
@@ -332,6 +339,7 @@ struct whisper_stream_state
     std::string prompt;
     int n_threads = 4;
     bool translate = false;
+    bool suppress_nst = false;
     std::mutex mutex;
 };
 
@@ -354,6 +362,7 @@ static json stream_run_inference()
     wparams.language         = g_stream.language.c_str();
     wparams.n_threads        = g_stream.n_threads;
     wparams.no_context       = true;
+    wparams.suppress_non_speech_tokens = g_stream.suppress_nst;
     if (!g_stream.prompt.empty()) {
         wparams.initial_prompt = g_stream.prompt.c_str();
     }
@@ -413,6 +422,7 @@ extern "C"
         g_stream.language  = jsonBody.value("language", "en");
         g_stream.n_threads = jsonBody.value("threads", 4);
         g_stream.translate = jsonBody.value("is_translate", false);
+        g_stream.suppress_nst = jsonBody.value("suppress_non_speech_tokens", false);
         g_stream.prompt.clear();
         if (jsonBody.contains("initial_prompt") && jsonBody["initial_prompt"].is_string()) {
             g_stream.prompt = jsonBody["initial_prompt"].get<std::string>();

--- a/android/src/whisper/main.cpp
+++ b/android/src/whisper/main.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <string>
 #include <thread>
+#include <mutex>
 #include <vector>
 #include <cmath>
 #include <iostream>
@@ -299,5 +300,188 @@ extern "C"
             jsonResult["message"] = e.what();
             return jsonToChar(jsonResult);
         }
+    }
+}
+// ---------------------------------------------------------------------------
+// Live (streaming) transcription.
+//
+// Unlike request()/transcribe(), which load the model on every call, a stream
+// keeps one whisper_context alive for the whole session:
+//
+//   stream_start(json)          -> loads the model, resets state
+//   stream_feed(pcm, n)         -> appends 16 kHz mono float samples; re-runs
+//                                  inference when >= ~1.5 s of new audio has
+//                                  accumulated and returns the partial text
+//   stream_stop()               -> final text, frees the context
+//
+// Partials re-decode the whole current window with no_context = true, so a
+// wrong early partial does not condition later ones. When the window grows
+// past ~25 s its text is committed and the buffer restarts, keeping memory
+// and inference time bounded (a word straddling the commit boundary may be
+// clipped — acceptable for a draft).
+// ---------------------------------------------------------------------------
+
+struct whisper_stream_state
+{
+    struct whisper_context *ctx = nullptr;
+    std::vector<float> pcmf32;   // samples of the current window
+    size_t n_transcribed = 0;    // window samples covered by the last run
+    std::string committed;       // text of windows already committed
+    std::string last_text;       // text of the current window's last run
+    std::string language = "en";
+    std::string prompt;
+    int n_threads = 4;
+    bool translate = false;
+    std::mutex mutex;
+};
+
+static whisper_stream_state g_stream;
+
+static const size_t STREAM_STEP_SAMPLES   = (size_t)(1.5 * WHISPER_SAMPLE_RATE);
+static const size_t STREAM_COMMIT_SAMPLES = (size_t)(25.0 * WHISPER_SAMPLE_RATE);
+
+// Runs whisper_full over the current window. Caller must hold g_stream.mutex.
+static json stream_run_inference()
+{
+    json result;
+    result["@type"] = "streamPartial";
+
+    whisper_full_params wparams = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+    wparams.print_realtime   = false;
+    wparams.print_progress   = false;
+    wparams.print_timestamps = false;
+    wparams.translate        = g_stream.translate;
+    wparams.language         = g_stream.language.c_str();
+    wparams.n_threads        = g_stream.n_threads;
+    wparams.no_context       = true;
+    if (!g_stream.prompt.empty()) {
+        wparams.initial_prompt = g_stream.prompt.c_str();
+    }
+
+    if (whisper_full(g_stream.ctx, wparams, g_stream.pcmf32.data(),
+                     (int)g_stream.pcmf32.size()) != 0) {
+        result["@type"] = "error";
+        result["message"] = "failed to process audio";
+        return result;
+    }
+
+    std::string text;
+    const int n_segments = whisper_full_n_segments(g_stream.ctx);
+    for (int i = 0; i < n_segments; ++i) {
+        text += whisper_full_get_segment_text(g_stream.ctx, i);
+    }
+
+    g_stream.last_text = text;
+    g_stream.n_transcribed = g_stream.pcmf32.size();
+
+    if (g_stream.pcmf32.size() >= STREAM_COMMIT_SAMPLES) {
+        g_stream.committed += text;
+        g_stream.last_text.clear();
+        g_stream.pcmf32.clear();
+        g_stream.n_transcribed = 0;
+    }
+
+    result["text"] = g_stream.committed + g_stream.last_text;
+    return result;
+}
+
+extern "C"
+{
+    // body: {"model": path, "language": "en", "threads": 4,
+    //        "is_translate": false, "initial_prompt": "..."}
+    char *stream_start(char *body)
+    {
+        std::lock_guard<std::mutex> lock(g_stream.mutex);
+        json jsonResult;
+
+        json jsonBody = json::parse(body, nullptr, false);
+        if (jsonBody.is_discarded() || !jsonBody.contains("model")) {
+            jsonResult["@type"] = "error";
+            jsonResult["message"] = "stream_start: invalid request body";
+            return jsonToChar(jsonResult);
+        }
+
+        if (g_stream.ctx != nullptr) {
+            whisper_free(g_stream.ctx);
+            g_stream.ctx = nullptr;
+        }
+        g_stream.pcmf32.clear();
+        g_stream.n_transcribed = 0;
+        g_stream.committed.clear();
+        g_stream.last_text.clear();
+
+        g_stream.language  = jsonBody.value("language", "en");
+        g_stream.n_threads = jsonBody.value("threads", 4);
+        g_stream.translate = jsonBody.value("is_translate", false);
+        g_stream.prompt.clear();
+        if (jsonBody.contains("initial_prompt") && jsonBody["initial_prompt"].is_string()) {
+            g_stream.prompt = jsonBody["initial_prompt"].get<std::string>();
+        }
+
+        const std::string model = jsonBody["model"].get<std::string>();
+        g_stream.ctx = whisper_init_from_file(model.c_str());
+        if (g_stream.ctx == nullptr) {
+            jsonResult["@type"] = "error";
+            jsonResult["message"] = "stream_start: failed to load model " + model;
+            return jsonToChar(jsonResult);
+        }
+
+        jsonResult["@type"] = "streamStarted";
+        return jsonToChar(jsonResult);
+    }
+
+    // pcm: 16 kHz mono float32 samples in [-1, 1].
+    char *stream_feed(const float *pcm, int32_t n_samples)
+    {
+        std::lock_guard<std::mutex> lock(g_stream.mutex);
+        json jsonResult;
+
+        if (g_stream.ctx == nullptr) {
+            jsonResult["@type"] = "error";
+            jsonResult["message"] = "stream_feed: stream not started";
+            return jsonToChar(jsonResult);
+        }
+        if (pcm != nullptr && n_samples > 0) {
+            g_stream.pcmf32.insert(g_stream.pcmf32.end(), pcm, pcm + n_samples);
+        }
+
+        if (g_stream.pcmf32.size() - g_stream.n_transcribed >= STREAM_STEP_SAMPLES) {
+            return jsonToChar(stream_run_inference());
+        }
+
+        jsonResult["@type"] = "streamPartial";
+        jsonResult["text"] = g_stream.committed + g_stream.last_text;
+        return jsonToChar(jsonResult);
+    }
+
+    char *stream_stop()
+    {
+        std::lock_guard<std::mutex> lock(g_stream.mutex);
+        json jsonResult;
+
+        if (g_stream.ctx == nullptr) {
+            jsonResult["@type"] = "error";
+            jsonResult["message"] = "stream_stop: stream not started";
+            return jsonToChar(jsonResult);
+        }
+
+        // Cover whatever audio arrived after the last run.
+        if (g_stream.pcmf32.size() > g_stream.n_transcribed &&
+            g_stream.pcmf32.size() >= (size_t)WHISPER_SAMPLE_RATE / 2) {
+            stream_run_inference();
+        }
+
+        jsonResult["@type"] = "streamFinal";
+        jsonResult["text"] = g_stream.committed + g_stream.last_text;
+
+        whisper_free(g_stream.ctx);
+        g_stream.ctx = nullptr;
+        g_stream.pcmf32.clear();
+        g_stream.pcmf32.shrink_to_fit();
+        g_stream.n_transcribed = 0;
+        g_stream.committed.clear();
+        g_stream.last_text.clear();
+
+        return jsonToChar(jsonResult);
     }
 }

--- a/android/src/whisper/main.cpp
+++ b/android/src/whisper/main.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <mutex>
 #include <algorithm>
+#include <cstdlib>
 #include <vector>
 #include <cmath>
 #include <iostream>
@@ -20,7 +21,9 @@ using json = nlohmann::json;
 char *jsonToChar(json jsonData) noexcept
 {
     std::string result = jsonData.dump();
-    char *ch = new char[result.size() + 1];
+    // malloc, not new[]: callers across the FFI boundary free this
+    // with the C allocator (Dart's malloc.free).
+    char *ch = (char *)malloc(result.size() + 1);
     strcpy(ch, result.c_str());
     return ch;
 }
@@ -341,6 +344,9 @@ struct whisper_stream_state
     size_t n_transcribed = 0;    // window samples covered by the last run
     size_t n_voiced = 0;         // end of the last chunk with speech energy
     float noise_floor = 0.005f;  // adaptive ambient RMS estimate
+    float gate_rms_min = 0.0015f;   // absolute minimum speech RMS
+    float gate_ratio = 2.5f;        // voiced thold = ratio * noise_floor
+    float gate_floor_cap = 0.01f;   // noise_floor cap (loud rooms)
     std::string committed;       // text of windows already committed
     std::string last_text;       // text of the current window's last run
     std::string language = "en";
@@ -355,8 +361,6 @@ static whisper_stream_state g_stream;
 
 static const size_t STREAM_STEP_SAMPLES   = (size_t)(1.5 * WHISPER_SAMPLE_RATE);
 static const size_t STREAM_COMMIT_SAMPLES = (size_t)(25.0 * WHISPER_SAMPLE_RATE);
-// Absolute minimum RMS for speech, regardless of the adaptive floor.
-static const float  STREAM_VOICE_RMS      = 0.0015f;
 // Decode this much audio past the last voiced sample (trailing consonants).
 static const size_t STREAM_VOICE_PAD      = (size_t)(0.2 * WHISPER_SAMPLE_RATE);
 
@@ -383,7 +387,7 @@ static json stream_run_inference()
     // whisper hallucinate (repeats or invented phrases).
     const size_t n_decode =
         std::min(g_stream.pcmf32.size(), g_stream.n_voiced + STREAM_VOICE_PAD);
-    if (n_decode == 0) {
+    if (n_decode < (size_t)WHISPER_SAMPLE_RATE / 2) {
         result["text"] = g_stream.committed + g_stream.last_text;
         return result;
     }
@@ -444,16 +448,28 @@ extern "C"
         g_stream.committed.clear();
         g_stream.last_text.clear();
 
-        g_stream.language  = jsonBody.value("language", "en");
-        g_stream.n_threads = jsonBody.value("threads", 4);
-        g_stream.translate = jsonBody.value("is_translate", false);
-        g_stream.suppress_nst = jsonBody.value("suppress_non_speech_tokens", false);
-        g_stream.prompt.clear();
-        if (jsonBody.contains("initial_prompt") && jsonBody["initial_prompt"].is_string()) {
-            g_stream.prompt = jsonBody["initial_prompt"].get<std::string>();
+        std::string model;
+        try {
+            g_stream.language  = jsonBody.value("language", "en");
+            g_stream.n_threads = jsonBody.value("threads", 4);
+            g_stream.translate = jsonBody.value("is_translate", false);
+            g_stream.suppress_nst = jsonBody.value("suppress_non_speech_tokens", false);
+            g_stream.gate_rms_min   = (float)jsonBody.value("gate_rms_min", 0.0015);
+            g_stream.gate_ratio     = (float)jsonBody.value("gate_voice_ratio", 2.5);
+            g_stream.gate_floor_cap = (float)jsonBody.value("gate_floor_cap", 0.01);
+            g_stream.prompt.clear();
+            if (jsonBody.contains("initial_prompt") && jsonBody["initial_prompt"].is_string()) {
+                g_stream.prompt = jsonBody["initial_prompt"].get<std::string>();
+            }
+            model = jsonBody["model"].get<std::string>();
+        } catch (const json::exception &e) {
+            // A C++ exception escaping extern "C" into FFI would be
+            // std::terminate; convert type errors to an error response.
+            jsonResult["@type"] = "error";
+            jsonResult["message"] =
+                std::string("stream_start: bad request: ") + e.what();
+            return jsonToChar(jsonResult);
         }
-
-        const std::string model = jsonBody["model"].get<std::string>();
         g_stream.ctx = whisper_init_from_file(model.c_str());
         if (g_stream.ctx == nullptr) {
             jsonResult["@type"] = "error";
@@ -492,9 +508,11 @@ extern "C"
             } else {
                 g_stream.noise_floor += 0.0005f * (rms - g_stream.noise_floor);
             }
-            g_stream.noise_floor = std::min(g_stream.noise_floor, 0.01f);
-            const float voice_thold =
-                std::max(2.5f * g_stream.noise_floor, STREAM_VOICE_RMS);
+            g_stream.noise_floor =
+                std::min(g_stream.noise_floor, g_stream.gate_floor_cap);
+            const float voice_thold = std::max(
+                g_stream.gate_ratio * g_stream.noise_floor,
+                g_stream.gate_rms_min);
             if (rms >= voice_thold) {
                 g_stream.n_voiced = g_stream.pcmf32.size();
             }

--- a/android/src/whisper/main.cpp
+++ b/android/src/whisper/main.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <thread>
 #include <mutex>
+#include <algorithm>
 #include <vector>
 #include <cmath>
 #include <iostream>
@@ -326,6 +327,11 @@ extern "C"
 // past ~25 s its text is committed and the buffer restarts, keeping memory
 // and inference time bounded (a word straddling the commit boundary may be
 // clipped — acceptable for a draft).
+//
+// An RMS energy gate tracks the last voiced sample: inference only runs
+// when new voiced audio has arrived, and the decoded window is trimmed
+// shortly after the last voiced sample. Without this, whisper hallucinates
+// over trailing silence (repeating earlier text or inventing phrases).
 // ---------------------------------------------------------------------------
 
 struct whisper_stream_state
@@ -333,6 +339,8 @@ struct whisper_stream_state
     struct whisper_context *ctx = nullptr;
     std::vector<float> pcmf32;   // samples of the current window
     size_t n_transcribed = 0;    // window samples covered by the last run
+    size_t n_voiced = 0;         // end of the last chunk with speech energy
+    float noise_floor = 0.005f;  // adaptive ambient RMS estimate
     std::string committed;       // text of windows already committed
     std::string last_text;       // text of the current window's last run
     std::string language = "en";
@@ -347,6 +355,10 @@ static whisper_stream_state g_stream;
 
 static const size_t STREAM_STEP_SAMPLES   = (size_t)(1.5 * WHISPER_SAMPLE_RATE);
 static const size_t STREAM_COMMIT_SAMPLES = (size_t)(25.0 * WHISPER_SAMPLE_RATE);
+// Absolute minimum RMS for speech, regardless of the adaptive floor.
+static const float  STREAM_VOICE_RMS      = 0.0015f;
+// Decode this much audio past the last voiced sample (trailing consonants).
+static const size_t STREAM_VOICE_PAD      = (size_t)(0.2 * WHISPER_SAMPLE_RATE);
 
 // Runs whisper_full over the current window. Caller must hold g_stream.mutex.
 static json stream_run_inference()
@@ -367,8 +379,17 @@ static json stream_run_inference()
         wparams.initial_prompt = g_stream.prompt.c_str();
     }
 
+    // Trim trailing silence from the decode window; decoding it makes
+    // whisper hallucinate (repeats or invented phrases).
+    const size_t n_decode =
+        std::min(g_stream.pcmf32.size(), g_stream.n_voiced + STREAM_VOICE_PAD);
+    if (n_decode == 0) {
+        result["text"] = g_stream.committed + g_stream.last_text;
+        return result;
+    }
+
     if (whisper_full(g_stream.ctx, wparams, g_stream.pcmf32.data(),
-                     (int)g_stream.pcmf32.size()) != 0) {
+                     (int)n_decode) != 0) {
         result["@type"] = "error";
         result["message"] = "failed to process audio";
         return result;
@@ -381,13 +402,15 @@ static json stream_run_inference()
     }
 
     g_stream.last_text = text;
-    g_stream.n_transcribed = g_stream.pcmf32.size();
+    g_stream.n_transcribed = n_decode;
 
-    if (g_stream.pcmf32.size() >= STREAM_COMMIT_SAMPLES) {
+    if (n_decode >= STREAM_COMMIT_SAMPLES) {
         g_stream.committed += text;
         g_stream.last_text.clear();
-        g_stream.pcmf32.clear();
+        g_stream.pcmf32.erase(g_stream.pcmf32.begin(),
+                              g_stream.pcmf32.begin() + n_decode);
         g_stream.n_transcribed = 0;
+        g_stream.n_voiced -= std::min(g_stream.n_voiced, n_decode);
     }
 
     result["text"] = g_stream.committed + g_stream.last_text;
@@ -416,6 +439,8 @@ extern "C"
         }
         g_stream.pcmf32.clear();
         g_stream.n_transcribed = 0;
+        g_stream.n_voiced = 0;
+        g_stream.noise_floor = 0.005f;
         g_stream.committed.clear();
         g_stream.last_text.clear();
 
@@ -452,10 +477,33 @@ extern "C"
             return jsonToChar(jsonResult);
         }
         if (pcm != nullptr && n_samples > 0) {
+            double sum2 = 0.0;
+            for (int32_t i = 0; i < n_samples; ++i) {
+                sum2 += (double)pcm[i] * pcm[i];
+            }
             g_stream.pcmf32.insert(g_stream.pcmf32.end(), pcm, pcm + n_samples);
+
+            // Adaptive noise floor: falls quickly, rises slowly, so it
+            // tracks room tone without absorbing speech. A chunk is
+            // voiced only when clearly above the floor.
+            const float rms = (float)std::sqrt(sum2 / n_samples);
+            if (rms < g_stream.noise_floor) {
+                g_stream.noise_floor += 0.5f * (rms - g_stream.noise_floor);
+            } else {
+                g_stream.noise_floor += 0.0005f * (rms - g_stream.noise_floor);
+            }
+            g_stream.noise_floor = std::min(g_stream.noise_floor, 0.01f);
+            const float voice_thold =
+                std::max(2.5f * g_stream.noise_floor, STREAM_VOICE_RMS);
+            if (rms >= voice_thold) {
+                g_stream.n_voiced = g_stream.pcmf32.size();
+            }
         }
 
-        if (g_stream.pcmf32.size() - g_stream.n_transcribed >= STREAM_STEP_SAMPLES) {
+        // Run only when new *voiced* audio arrived — silence alone
+        // never triggers a decode.
+        if (g_stream.n_voiced > g_stream.n_transcribed &&
+            g_stream.pcmf32.size() - g_stream.n_transcribed >= STREAM_STEP_SAMPLES) {
             return jsonToChar(stream_run_inference());
         }
 
@@ -475,9 +523,12 @@ extern "C"
             return jsonToChar(jsonResult);
         }
 
-        // Cover whatever audio arrived after the last run.
-        if (g_stream.pcmf32.size() > g_stream.n_transcribed &&
-            g_stream.pcmf32.size() >= (size_t)WHISPER_SAMPLE_RATE / 2) {
+        // Cover voiced audio that arrived after the last run; a silent
+        // tail is dropped rather than decoded.
+        const size_t n_tail = std::min(g_stream.pcmf32.size(),
+                                       g_stream.n_voiced + STREAM_VOICE_PAD);
+        if (g_stream.n_voiced > g_stream.n_transcribed &&
+            n_tail >= (size_t)WHISPER_SAMPLE_RATE / 2) {
             stream_run_inference();
         }
 
@@ -489,6 +540,7 @@ extern "C"
         g_stream.pcmf32.clear();
         g_stream.pcmf32.shrink_to_fit();
         g_stream.n_transcribed = 0;
+        g_stream.n_voiced = 0;
         g_stream.committed.clear();
         g_stream.last_text.clear();
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,10 @@
+# Restrict code generation to the package sources. Without this,
+# build_runner crawls example/ios/.symlinks and .fvm/flutter_sdk (symlinks
+# back into the plugin and the whole Flutter SDK) — ~49k inputs.
+targets:
+  $default:
+    sources:
+      include:
+        - lib/**
+        - test/**
+        - pubspec.yaml

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,6 +44,7 @@ class _MyHomePageState extends State<MyHomePage> {
   String? transcript;
   MicMode activeMode = MicMode.none;
   bool isTranscribing = false;
+  bool _actionInFlight = false;
   WhisperLiveSession? liveSession;
 
   /// Optional initial prompt that biases Whisper decoding toward specific
@@ -221,6 +222,19 @@ class _MyHomePageState extends State<MyHomePage> {
   /// Live transcription: transcripts appear while you speak instead of
   /// after recording stops.
   Future<void> toggleLive() async {
+    // The button stays enabled across the awaits below; without this guard
+    // a double-tap would start two recorder streams against the single
+    // native session.
+    if (_actionInFlight) return;
+    _actionInFlight = true;
+    try {
+      await _toggleLive();
+    } finally {
+      _actionInFlight = false;
+    }
+  }
+
+  Future<void> _toggleLive() async {
     if (!await audioRecorder.hasPermission()) return;
 
     if (activeMode == MicMode.live) {
@@ -262,11 +276,16 @@ class _MyHomePageState extends State<MyHomePage> {
       );
       liveSession = session;
 
-      session.partials.listen((text) {
-        if (mounted && text.isNotEmpty) {
-          setState(() => transcript = text);
-        }
-      });
+      session.partials.listen(
+        (text) {
+          if (mounted && text.isNotEmpty) {
+            setState(() => transcript = text);
+          }
+        },
+        // A fatal native error mid-session; the session finalizes itself
+        // and stop() still returns the last partial.
+        onError: (Object e) => debugPrint('Live transcription error: $e'),
+      );
 
       setState(() => activeMode = MicMode.live);
     }
@@ -275,6 +294,16 @@ class _MyHomePageState extends State<MyHomePage> {
   /// Classic transcription: records to a file, then transcribes it once
   /// recording stops.
   Future<void> toggleClassic() async {
+    if (_actionInFlight) return;
+    _actionInFlight = true;
+    try {
+      await _toggleClassic();
+    } finally {
+      _actionInFlight = false;
+    }
+  }
+
+  Future<void> _toggleClassic() async {
     if (!await audioRecorder.hasPermission()) return;
 
     if (activeMode == MicMode.classic) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -254,9 +254,11 @@ class _MyHomePageState extends State<MyHomePage> {
         pcm16Stream: pcmStream,
         lang: 'en',
         initialPrompt: _initialPrompt.isEmpty ? null : _initialPrompt,
-        // Silence between phrases would otherwise transcribe as
-        // annotations like [BLANK_AUDIO].
-        suppressNonSpeechTokens: true,
+        // Left false: with it, real non-speech sounds (knocks, clicks)
+        // decode as plausible-looking fake words instead of honest
+        // annotations like [gun shots]. Silence itself never reaches the
+        // decoder thanks to the native energy gate.
+        suppressNonSpeechTokens: false,
       );
       liveSession = session;
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -43,6 +44,7 @@ class _MyHomePageState extends State<MyHomePage> {
   bool isProcessing = false;
   bool isProcessingFile = false;
   bool isListening = false;
+  WhisperLiveSession? liveSession;
 
   /// Optional initial prompt that biases Whisper decoding toward specific
   /// vocabulary, names, and punctuation. Useful for domain-specific
@@ -128,51 +130,57 @@ class _MyHomePageState extends State<MyHomePage> {
     }
   }
 
+  /// Live transcription: transcripts appear while you speak instead of
+  /// after recording stops.
   Future<void> record() async {
-    if (await audioRecorder.hasPermission()) {
-      if (await audioRecorder.isRecording()) {
-        final audioPath = await audioRecorder.stop();
+    if (!await audioRecorder.hasPermission()) return;
 
-        if (audioPath != null) {
-          debugPrint('Stopped listening.');
+    if (isListening) {
+      debugPrint('Stopping live transcription.');
+      await audioRecorder.stop();
 
-          setState(() {
-            isListening = false;
-            isProcessing = true;
-          });
+      setState(() {
+        isListening = false;
+        isProcessing = true;
+      });
 
-          final result = await whisperController.transcribe(
-            model: model,
-            audioPath: audioPath,
-            lang: 'en',
-            initialPrompt: _initialPrompt.isEmpty ? null : _initialPrompt,
-          );
+      final String finalText = await liveSession?.stop() ?? '';
+      liveSession = null;
 
-          if (mounted) {
-            setState(() {
-              isProcessing = false;
-            });
-          }
-
-          if (result?.transcription.text != null) {
-            setState(() {
-              transcribedText = result!.transcription.text;
-            });
-          }
-        } else {
-          debugPrint('No recording exists.');
-        }
-      } else {
-        debugPrint('Started listening.');
-
+      if (mounted) {
         setState(() {
-          isListening = true;
+          isProcessing = false;
+          if (finalText.isNotEmpty) transcribedText = finalText;
         });
-
-        final Directory appDirectory = await getTemporaryDirectory();
-        await audioRecorder.start(const RecordConfig(),
-            path: '${appDirectory.path}/test.m4a');
       }
+    } else {
+      debugPrint('Starting live transcription.');
+
+      final Stream<Uint8List> pcmStream = await audioRecorder.startStream(
+        const RecordConfig(
+          encoder: AudioEncoder.pcm16bits,
+          sampleRate: 16000,
+          numChannels: 1,
+        ),
+      );
+
+      final session = await whisperController.transcribeLive(
+        model: model,
+        pcm16Stream: pcmStream,
+        lang: 'en',
+        initialPrompt: _initialPrompt.isEmpty ? null : _initialPrompt,
+      );
+      liveSession = session;
+
+      session.partials.listen((text) {
+        if (mounted && text.isNotEmpty) {
+          setState(() => transcribedText = text);
+        }
+      });
+
+      setState(() {
+        isListening = true;
+      });
     }
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,11 +1,10 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:whisper_ggml/whisper_ggml.dart';
 import 'package:record/record.dart';
+import 'package:whisper_ggml/whisper_ggml.dart';
 
 void main() {
   runApp(const MyApp());
@@ -27,9 +26,10 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  /// Modify this model based on your needs
+/// Which microphone flow is currently running.
+enum MicMode { none, live, classic }
 
+class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key});
 
   @override
@@ -40,14 +40,10 @@ class _MyHomePageState extends State<MyHomePage> {
   final model = WhisperModel.base;
   final AudioRecorder audioRecorder = AudioRecorder();
   final WhisperController whisperController = WhisperController();
-  String transcribedText = 'Transcribed text will be displayed here';
-  bool isProcessing = false;
-  bool isProcessingFile = false;
-  bool isListening = false;
 
-  /// Live mode shows partial transcripts while speaking; classic mode
-  /// records to a file and transcribes once recording stops.
-  bool liveMode = true;
+  String? transcript;
+  MicMode activeMode = MicMode.none;
+  bool isTranscribing = false;
   WhisperLiveSession? liveSession;
 
   /// Optional initial prompt that biases Whisper decoding toward specific
@@ -58,6 +54,8 @@ class _MyHomePageState extends State<MyHomePage> {
   /// style: an unpunctuated prompt tends to produce unpunctuated output.
   static const String _initialPrompt = '';
 
+  bool get _isBusy => isTranscribing || activeMode != MicMode.none;
+
   @override
   void initState() {
     initModel();
@@ -66,67 +64,142 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text('Whisper ggml example'),
-        actions: [
-          Text(liveMode ? 'Live' : 'Classic'),
-          Switch(
-            value: liveMode,
-            // Locked while a recording is in progress.
-            onChanged: isListening || isProcessing
-                ? null
-                : (value) => setState(() => liveMode = value),
-          ),
-          const SizedBox(width: 12),
-        ],
+        backgroundColor: colors.inversePrimary,
+        title: const Text('Whisper ggml example'),
       ),
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Stack(
-            fit: StackFit.expand,
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Center(
-                child: Text(
-                  transcribedText,
-                  style: Theme.of(context).textTheme.headlineMedium,
-                ),
-              ),
-              Positioned(
-                bottom: 24,
-                left: 0,
-                child: Tooltip(
-                  message: 'Transcribe jfk.wav asset file',
-                  child: CircleAvatar(
-                    backgroundColor: Colors.purple.shade100,
-                    maxRadius: 25,
-                    child: isProcessingFile
-                        ? const CircularProgressIndicator()
-                        : IconButton(
-                            onPressed: transcribeJfk,
-                            icon: Icon(
-                              Icons.folder,
-                            ),
-                          ),
-                  ),
-                ),
-              )
+              Expanded(child: _transcriptCard(colors)),
+              const SizedBox(height: 12),
+              _statusBar(colors),
+              const SizedBox(height: 12),
+              _actionBar(colors),
             ],
           ),
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: record,
-        tooltip: 'Start listening',
-        child: isProcessing
-            ? const CircularProgressIndicator()
-            : Icon(
-                isListening ? Icons.mic_off : Icons.mic,
-                color: isListening ? Colors.red : null,
-              ),
+    );
+  }
+
+  Widget _transcriptCard(ColorScheme colors) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: colors.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: colors.outlineVariant),
       ),
+      child: transcript == null
+          ? Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.subtitles_outlined, size: 48, color: colors.outline),
+                const SizedBox(height: 12),
+                Text(
+                  'Transcribed text will appear here',
+                  style: TextStyle(color: colors.outline),
+                ),
+              ],
+            )
+          : SingleChildScrollView(
+              child: SelectableText(
+                transcript!,
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+            ),
+    );
+  }
+
+  Widget _statusBar(ColorScheme colors) {
+    final (IconData, String)? status = switch ((activeMode, isTranscribing)) {
+      (MicMode.live, _) => (
+          Icons.graphic_eq,
+          'Listening — text updates as you speak',
+        ),
+      (MicMode.classic, _) => (
+          Icons.fiber_manual_record,
+          'Recording — transcribes when you stop',
+        ),
+      (MicMode.none, true) => (Icons.hourglass_top, 'Transcribing…'),
+      _ => null,
+    };
+
+    if (status == null) return const SizedBox(height: 20);
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(
+          status.$1,
+          size: 16,
+          color: activeMode != MicMode.none ? colors.error : colors.primary,
+        ),
+        const SizedBox(width: 8),
+        Text(status.$2, style: TextStyle(color: colors.onSurfaceVariant)),
+      ],
+    );
+  }
+
+  Widget _actionBar(ColorScheme colors) {
+    final bool liveActive = activeMode == MicMode.live;
+    final bool classicActive = activeMode == MicMode.classic;
+    const Size buttonSize = Size.fromHeight(48);
+
+    return Row(
+      children: [
+        Expanded(
+          child: Tooltip(
+            message: 'Transcribe live while you speak',
+            child: FilledButton.icon(
+              onPressed: isTranscribing || classicActive ? null : toggleLive,
+              style: FilledButton.styleFrom(
+                minimumSize: buttonSize,
+                backgroundColor: liveActive ? colors.error : null,
+                foregroundColor: liveActive ? colors.onError : null,
+              ),
+              icon: Icon(liveActive ? Icons.stop : Icons.graphic_eq),
+              label: Text(liveActive ? 'Stop' : 'Live mic'),
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Tooltip(
+            message: 'Record first, transcribe after you stop',
+            child: FilledButton.tonalIcon(
+              onPressed: isTranscribing || liveActive ? null : toggleClassic,
+              style: FilledButton.styleFrom(
+                minimumSize: buttonSize,
+                backgroundColor: classicActive ? colors.error : null,
+                foregroundColor: classicActive ? colors.onError : null,
+              ),
+              icon: Icon(classicActive ? Icons.stop : Icons.mic),
+              label: Text(classicActive ? 'Stop' : 'Record'),
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Tooltip(
+            message: 'Transcribe the bundled JFK sample clip',
+            child: OutlinedButton.icon(
+              onPressed: _isBusy ? null : transcribeJfk,
+              style: OutlinedButton.styleFrom(minimumSize: buttonSize),
+              icon: const Icon(Icons.play_circle_outline),
+              label: const Text('JFK sample'),
+            ),
+          ),
+        ),
+      ],
     );
   }
 
@@ -145,21 +218,17 @@ class _MyHomePageState extends State<MyHomePage> {
     }
   }
 
-  Future<void> record() async {
-    if (!await audioRecorder.hasPermission()) return;
-    return liveMode ? recordLive() : recordClassic();
-  }
-
   /// Live transcription: transcripts appear while you speak instead of
   /// after recording stops.
-  Future<void> recordLive() async {
-    if (isListening) {
-      debugPrint('Stopping live transcription.');
+  Future<void> toggleLive() async {
+    if (!await audioRecorder.hasPermission()) return;
+
+    if (activeMode == MicMode.live) {
       await audioRecorder.stop();
 
       setState(() {
-        isListening = false;
-        isProcessing = true;
+        activeMode = MicMode.none;
+        isTranscribing = true;
       });
 
       final String finalText = await liveSession?.stop() ?? '';
@@ -167,13 +236,11 @@ class _MyHomePageState extends State<MyHomePage> {
 
       if (mounted) {
         setState(() {
-          isProcessing = false;
-          if (finalText.isNotEmpty) transcribedText = finalText;
+          isTranscribing = false;
+          if (finalText.isNotEmpty) transcript = finalText;
         });
       }
     } else {
-      debugPrint('Starting live transcription.');
-
       final Stream<Uint8List> pcmStream = await audioRecorder.startStream(
         const RecordConfig(
           encoder: AudioEncoder.pcm16bits,
@@ -192,32 +259,31 @@ class _MyHomePageState extends State<MyHomePage> {
 
       session.partials.listen((text) {
         if (mounted && text.isNotEmpty) {
-          setState(() => transcribedText = text);
+          setState(() => transcript = text);
         }
       });
 
-      setState(() {
-        isListening = true;
-      });
+      setState(() => activeMode = MicMode.live);
     }
   }
 
   /// Classic transcription: records to a file, then transcribes it once
   /// recording stops.
-  Future<void> recordClassic() async {
-    if (isListening) {
+  Future<void> toggleClassic() async {
+    if (!await audioRecorder.hasPermission()) return;
+
+    if (activeMode == MicMode.classic) {
       final audioPath = await audioRecorder.stop();
+
+      setState(() {
+        activeMode = MicMode.none;
+        isTranscribing = audioPath != null;
+      });
 
       if (audioPath == null) {
         debugPrint('No recording exists.');
         return;
       }
-      debugPrint('Stopped listening.');
-
-      setState(() {
-        isListening = false;
-        isProcessing = true;
-      });
 
       final result = await whisperController.transcribe(
         model: model,
@@ -228,23 +294,19 @@ class _MyHomePageState extends State<MyHomePage> {
 
       if (mounted) {
         setState(() {
-          isProcessing = false;
+          isTranscribing = false;
           if (result?.transcription.text != null) {
-            transcribedText = result!.transcription.text;
+            transcript = result!.transcription.text;
           }
         });
       }
     } else {
-      debugPrint('Started listening.');
-
-      setState(() {
-        isListening = true;
-      });
-
       final Directory appDirectory = await getTemporaryDirectory();
       await appDirectory.create(recursive: true);
       await audioRecorder.start(const RecordConfig(),
           path: '${appDirectory.path}/test.m4a');
+
+      setState(() => activeMode = MicMode.classic);
     }
   }
 
@@ -258,9 +320,7 @@ class _MyHomePageState extends State<MyHomePage> {
       asset.buffer.asUint8List(),
     );
 
-    setState(() {
-      isProcessingFile = true;
-    });
+    setState(() => isTranscribing = true);
 
     final result = await whisperController.transcribe(
       model: model,
@@ -269,13 +329,12 @@ class _MyHomePageState extends State<MyHomePage> {
       initialPrompt: _initialPrompt.isEmpty ? null : _initialPrompt,
     );
 
-    setState(() {
-      isProcessingFile = false;
-    });
-
-    if (result?.transcription.text != null) {
+    if (mounted) {
       setState(() {
-        transcribedText = result!.transcription.text;
+        isTranscribing = false;
+        if (result?.transcription.text != null) {
+          transcript = result!.transcription.text;
+        }
       });
     }
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,6 +44,10 @@ class _MyHomePageState extends State<MyHomePage> {
   bool isProcessing = false;
   bool isProcessingFile = false;
   bool isListening = false;
+
+  /// Live mode shows partial transcripts while speaking; classic mode
+  /// records to a file and transcribes once recording stops.
+  bool liveMode = true;
   WhisperLiveSession? liveSession;
 
   /// Optional initial prompt that biases Whisper decoding toward specific
@@ -66,6 +70,17 @@ class _MyHomePageState extends State<MyHomePage> {
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: Text('Whisper ggml example'),
+        actions: [
+          Text(liveMode ? 'Live' : 'Classic'),
+          Switch(
+            value: liveMode,
+            // Locked while a recording is in progress.
+            onChanged: isListening || isProcessing
+                ? null
+                : (value) => setState(() => liveMode = value),
+          ),
+          const SizedBox(width: 12),
+        ],
       ),
       body: SafeArea(
         child: Padding(
@@ -130,11 +145,14 @@ class _MyHomePageState extends State<MyHomePage> {
     }
   }
 
-  /// Live transcription: transcripts appear while you speak instead of
-  /// after recording stops.
   Future<void> record() async {
     if (!await audioRecorder.hasPermission()) return;
+    return liveMode ? recordLive() : recordClassic();
+  }
 
+  /// Live transcription: transcripts appear while you speak instead of
+  /// after recording stops.
+  Future<void> recordLive() async {
     if (isListening) {
       debugPrint('Stopping live transcription.');
       await audioRecorder.stop();
@@ -181,6 +199,52 @@ class _MyHomePageState extends State<MyHomePage> {
       setState(() {
         isListening = true;
       });
+    }
+  }
+
+  /// Classic transcription: records to a file, then transcribes it once
+  /// recording stops.
+  Future<void> recordClassic() async {
+    if (isListening) {
+      final audioPath = await audioRecorder.stop();
+
+      if (audioPath == null) {
+        debugPrint('No recording exists.');
+        return;
+      }
+      debugPrint('Stopped listening.');
+
+      setState(() {
+        isListening = false;
+        isProcessing = true;
+      });
+
+      final result = await whisperController.transcribe(
+        model: model,
+        audioPath: audioPath,
+        lang: 'en',
+        initialPrompt: _initialPrompt.isEmpty ? null : _initialPrompt,
+      );
+
+      if (mounted) {
+        setState(() {
+          isProcessing = false;
+          if (result?.transcription.text != null) {
+            transcribedText = result!.transcription.text;
+          }
+        });
+      }
+    } else {
+      debugPrint('Started listening.');
+
+      setState(() {
+        isListening = true;
+      });
+
+      final Directory appDirectory = await getTemporaryDirectory();
+      await appDirectory.create(recursive: true);
+      await audioRecorder.start(const RecordConfig(),
+          path: '${appDirectory.path}/test.m4a');
     }
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -254,6 +254,9 @@ class _MyHomePageState extends State<MyHomePage> {
         pcm16Stream: pcmStream,
         lang: 'en',
         initialPrompt: _initialPrompt.isEmpty ? null : _initialPrompt,
+        // Silence between phrases would otherwise transcribe as
+        // annotations like [BLANK_AUDIO].
+        suppressNonSpeechTokens: true,
       );
       liveSession = session;
 

--- a/example/macos/Runner/DebugProfile.entitlements
+++ b/example/macos/Runner/DebugProfile.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/example/macos/Runner/Release.entitlements
+++ b/example/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/ios/Classes/whisper_flutter_plus.cpp
+++ b/ios/Classes/whisper_flutter_plus.cpp
@@ -10,6 +10,7 @@
 #include <thread>
 #include <mutex>
 #include <algorithm>
+#include <cstdlib>
 #include <vector>
 
 #include <iostream>
@@ -26,7 +27,9 @@ void print(std::string value)
 char *jsonToChar(json jsonData)
 {
     std::string result = jsonData.dump();
-    char *ch = new char[result.size() + 1];
+    // malloc, not new[]: callers across the FFI boundary free this
+    // with the C allocator (Dart's malloc.free).
+    char *ch = (char *)malloc(result.size() + 1);
     strcpy(ch, result.c_str());
     return ch;
 }
@@ -39,7 +42,7 @@ std::string charToString(char *value)
 
 char *stringToChar(std::string value)
 {
-    char *ch = new char[value.size() + 1];
+    char *ch = (char *)malloc(value.size() + 1);
     strcpy(ch, value.c_str());
     return ch;
 }
@@ -421,6 +424,9 @@ struct whisper_stream_state
     size_t n_transcribed = 0;    // window samples covered by the last run
     size_t n_voiced = 0;         // end of the last chunk with speech energy
     float noise_floor = 0.005f;  // adaptive ambient RMS estimate
+    float gate_rms_min = 0.0015f;   // absolute minimum speech RMS
+    float gate_ratio = 2.5f;        // voiced thold = ratio * noise_floor
+    float gate_floor_cap = 0.01f;   // noise_floor cap (loud rooms)
     std::string committed;       // text of windows already committed
     std::string last_text;       // text of the current window's last run
     std::string language = "en";
@@ -435,8 +441,6 @@ static whisper_stream_state g_stream;
 
 static const size_t STREAM_STEP_SAMPLES   = (size_t)(1.5 * WHISPER_SAMPLE_RATE);
 static const size_t STREAM_COMMIT_SAMPLES = (size_t)(25.0 * WHISPER_SAMPLE_RATE);
-// Absolute minimum RMS for speech, regardless of the adaptive floor.
-static const float  STREAM_VOICE_RMS      = 0.0015f;
 // Decode this much audio past the last voiced sample (trailing consonants).
 static const size_t STREAM_VOICE_PAD      = (size_t)(0.2 * WHISPER_SAMPLE_RATE);
 
@@ -463,7 +467,7 @@ static json stream_run_inference()
     // whisper hallucinate (repeats or invented phrases).
     const size_t n_decode =
         std::min(g_stream.pcmf32.size(), g_stream.n_voiced + STREAM_VOICE_PAD);
-    if (n_decode == 0) {
+    if (n_decode < (size_t)WHISPER_SAMPLE_RATE / 2) {
         result["text"] = g_stream.committed + g_stream.last_text;
         return result;
     }
@@ -524,16 +528,28 @@ extern "C"
         g_stream.committed.clear();
         g_stream.last_text.clear();
 
-        g_stream.language  = jsonBody.value("language", "en");
-        g_stream.n_threads = jsonBody.value("threads", 4);
-        g_stream.translate = jsonBody.value("is_translate", false);
-        g_stream.suppress_nst = jsonBody.value("suppress_non_speech_tokens", false);
-        g_stream.prompt.clear();
-        if (jsonBody.contains("initial_prompt") && jsonBody["initial_prompt"].is_string()) {
-            g_stream.prompt = jsonBody["initial_prompt"].get<std::string>();
+        std::string model;
+        try {
+            g_stream.language  = jsonBody.value("language", "en");
+            g_stream.n_threads = jsonBody.value("threads", 4);
+            g_stream.translate = jsonBody.value("is_translate", false);
+            g_stream.suppress_nst = jsonBody.value("suppress_non_speech_tokens", false);
+            g_stream.gate_rms_min   = (float)jsonBody.value("gate_rms_min", 0.0015);
+            g_stream.gate_ratio     = (float)jsonBody.value("gate_voice_ratio", 2.5);
+            g_stream.gate_floor_cap = (float)jsonBody.value("gate_floor_cap", 0.01);
+            g_stream.prompt.clear();
+            if (jsonBody.contains("initial_prompt") && jsonBody["initial_prompt"].is_string()) {
+                g_stream.prompt = jsonBody["initial_prompt"].get<std::string>();
+            }
+            model = jsonBody["model"].get<std::string>();
+        } catch (const json::exception &e) {
+            // A C++ exception escaping extern "C" into FFI would be
+            // std::terminate; convert type errors to an error response.
+            jsonResult["@type"] = "error";
+            jsonResult["message"] =
+                std::string("stream_start: bad request: ") + e.what();
+            return jsonToChar(jsonResult);
         }
-
-        const std::string model = jsonBody["model"].get<std::string>();
         g_stream.ctx = whisper_init_from_file(model.c_str());
         if (g_stream.ctx == nullptr) {
             jsonResult["@type"] = "error";
@@ -572,9 +588,11 @@ extern "C"
             } else {
                 g_stream.noise_floor += 0.0005f * (rms - g_stream.noise_floor);
             }
-            g_stream.noise_floor = std::min(g_stream.noise_floor, 0.01f);
-            const float voice_thold =
-                std::max(2.5f * g_stream.noise_floor, STREAM_VOICE_RMS);
+            g_stream.noise_floor =
+                std::min(g_stream.noise_floor, g_stream.gate_floor_cap);
+            const float voice_thold = std::max(
+                g_stream.gate_ratio * g_stream.noise_floor,
+                g_stream.gate_rms_min);
             if (rms >= voice_thold) {
                 g_stream.n_voiced = g_stream.pcmf32.size();
             }

--- a/ios/Classes/whisper_flutter_plus.cpp
+++ b/ios/Classes/whisper_flutter_plus.cpp
@@ -133,6 +133,8 @@ struct whisper_params
     bool split_on_word = false;
     // whisper_full_params.no_context: disable cross-segment text conditioning.
     bool no_context = false;
+    // whisper_full_params.suppress_non_speech_tokens: drop [BLANK_AUDIO]-style annotations.
+    bool suppress_nst = false;
 
     std::string language = "id";
     std::string prompt;
@@ -172,6 +174,10 @@ json transcribe(json jsonBody)
     if (jsonBody.contains("no_context") && jsonBody["no_context"].is_boolean())
     {
         params.no_context = jsonBody["no_context"].get<bool>();
+    }
+    if (jsonBody.contains("suppress_non_speech_tokens") && jsonBody["suppress_non_speech_tokens"].is_boolean())
+    {
+        params.suppress_nst = jsonBody["suppress_non_speech_tokens"].get<bool>();
     }
     json jsonResult;
     jsonResult["@type"] = "transcribe";
@@ -290,6 +296,7 @@ json transcribe(json jsonBody)
             wparams.initial_prompt = params.prompt.c_str();
         }
         wparams.no_context = params.no_context;
+        wparams.suppress_non_speech_tokens = params.suppress_nst;
 
         if (params.split_on_word) {
             wparams.max_len = 1;
@@ -412,6 +419,7 @@ struct whisper_stream_state
     std::string prompt;
     int n_threads = 4;
     bool translate = false;
+    bool suppress_nst = false;
     std::mutex mutex;
 };
 
@@ -434,6 +442,7 @@ static json stream_run_inference()
     wparams.language         = g_stream.language.c_str();
     wparams.n_threads        = g_stream.n_threads;
     wparams.no_context       = true;
+    wparams.suppress_non_speech_tokens = g_stream.suppress_nst;
     if (!g_stream.prompt.empty()) {
         wparams.initial_prompt = g_stream.prompt.c_str();
     }
@@ -493,6 +502,7 @@ extern "C"
         g_stream.language  = jsonBody.value("language", "en");
         g_stream.n_threads = jsonBody.value("threads", 4);
         g_stream.translate = jsonBody.value("is_translate", false);
+        g_stream.suppress_nst = jsonBody.value("suppress_non_speech_tokens", false);
         g_stream.prompt.clear();
         if (jsonBody.contains("initial_prompt") && jsonBody["initial_prompt"].is_string()) {
             g_stream.prompt = jsonBody["initial_prompt"].get<std::string>();

--- a/ios/Classes/whisper_flutter_plus.cpp
+++ b/ios/Classes/whisper_flutter_plus.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <string>
 #include <thread>
+#include <mutex>
 #include <vector>
 
 #include <iostream>
@@ -378,5 +379,189 @@ extern "C"
         jsonBody["@type"] = "al";
         print(transcribe(jsonBody).dump());
         return 0;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Live (streaming) transcription.
+//
+// Unlike request()/transcribe(), which load the model on every call, a stream
+// keeps one whisper_context alive for the whole session:
+//
+//   stream_start(json)          -> loads the model, resets state
+//   stream_feed(pcm, n)         -> appends 16 kHz mono float samples; re-runs
+//                                  inference when >= ~1.5 s of new audio has
+//                                  accumulated and returns the partial text
+//   stream_stop()               -> final text, frees the context
+//
+// Partials re-decode the whole current window with no_context = true, so a
+// wrong early partial does not condition later ones. When the window grows
+// past ~25 s its text is committed and the buffer restarts, keeping memory
+// and inference time bounded (a word straddling the commit boundary may be
+// clipped — acceptable for a draft).
+// ---------------------------------------------------------------------------
+
+struct whisper_stream_state
+{
+    struct whisper_context *ctx = nullptr;
+    std::vector<float> pcmf32;   // samples of the current window
+    size_t n_transcribed = 0;    // window samples covered by the last run
+    std::string committed;       // text of windows already committed
+    std::string last_text;       // text of the current window's last run
+    std::string language = "en";
+    std::string prompt;
+    int n_threads = 4;
+    bool translate = false;
+    std::mutex mutex;
+};
+
+static whisper_stream_state g_stream;
+
+static const size_t STREAM_STEP_SAMPLES   = (size_t)(1.5 * WHISPER_SAMPLE_RATE);
+static const size_t STREAM_COMMIT_SAMPLES = (size_t)(25.0 * WHISPER_SAMPLE_RATE);
+
+// Runs whisper_full over the current window. Caller must hold g_stream.mutex.
+static json stream_run_inference()
+{
+    json result;
+    result["@type"] = "streamPartial";
+
+    whisper_full_params wparams = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+    wparams.print_realtime   = false;
+    wparams.print_progress   = false;
+    wparams.print_timestamps = false;
+    wparams.translate        = g_stream.translate;
+    wparams.language         = g_stream.language.c_str();
+    wparams.n_threads        = g_stream.n_threads;
+    wparams.no_context       = true;
+    if (!g_stream.prompt.empty()) {
+        wparams.initial_prompt = g_stream.prompt.c_str();
+    }
+
+    if (whisper_full(g_stream.ctx, wparams, g_stream.pcmf32.data(),
+                     (int)g_stream.pcmf32.size()) != 0) {
+        result["@type"] = "error";
+        result["message"] = "failed to process audio";
+        return result;
+    }
+
+    std::string text;
+    const int n_segments = whisper_full_n_segments(g_stream.ctx);
+    for (int i = 0; i < n_segments; ++i) {
+        text += whisper_full_get_segment_text(g_stream.ctx, i);
+    }
+
+    g_stream.last_text = text;
+    g_stream.n_transcribed = g_stream.pcmf32.size();
+
+    if (g_stream.pcmf32.size() >= STREAM_COMMIT_SAMPLES) {
+        g_stream.committed += text;
+        g_stream.last_text.clear();
+        g_stream.pcmf32.clear();
+        g_stream.n_transcribed = 0;
+    }
+
+    result["text"] = g_stream.committed + g_stream.last_text;
+    return result;
+}
+
+extern "C"
+{
+    // body: {"model": path, "language": "en", "threads": 4,
+    //        "is_translate": false, "initial_prompt": "..."}
+    char *stream_start(char *body)
+    {
+        std::lock_guard<std::mutex> lock(g_stream.mutex);
+        json jsonResult;
+
+        json jsonBody = json::parse(body, nullptr, false);
+        if (jsonBody.is_discarded() || !jsonBody.contains("model")) {
+            jsonResult["@type"] = "error";
+            jsonResult["message"] = "stream_start: invalid request body";
+            return jsonToChar(jsonResult);
+        }
+
+        if (g_stream.ctx != nullptr) {
+            whisper_free(g_stream.ctx);
+            g_stream.ctx = nullptr;
+        }
+        g_stream.pcmf32.clear();
+        g_stream.n_transcribed = 0;
+        g_stream.committed.clear();
+        g_stream.last_text.clear();
+
+        g_stream.language  = jsonBody.value("language", "en");
+        g_stream.n_threads = jsonBody.value("threads", 4);
+        g_stream.translate = jsonBody.value("is_translate", false);
+        g_stream.prompt.clear();
+        if (jsonBody.contains("initial_prompt") && jsonBody["initial_prompt"].is_string()) {
+            g_stream.prompt = jsonBody["initial_prompt"].get<std::string>();
+        }
+
+        const std::string model = jsonBody["model"].get<std::string>();
+        g_stream.ctx = whisper_init_from_file(model.c_str());
+        if (g_stream.ctx == nullptr) {
+            jsonResult["@type"] = "error";
+            jsonResult["message"] = "stream_start: failed to load model " + model;
+            return jsonToChar(jsonResult);
+        }
+
+        jsonResult["@type"] = "streamStarted";
+        return jsonToChar(jsonResult);
+    }
+
+    // pcm: 16 kHz mono float32 samples in [-1, 1].
+    char *stream_feed(const float *pcm, int32_t n_samples)
+    {
+        std::lock_guard<std::mutex> lock(g_stream.mutex);
+        json jsonResult;
+
+        if (g_stream.ctx == nullptr) {
+            jsonResult["@type"] = "error";
+            jsonResult["message"] = "stream_feed: stream not started";
+            return jsonToChar(jsonResult);
+        }
+        if (pcm != nullptr && n_samples > 0) {
+            g_stream.pcmf32.insert(g_stream.pcmf32.end(), pcm, pcm + n_samples);
+        }
+
+        if (g_stream.pcmf32.size() - g_stream.n_transcribed >= STREAM_STEP_SAMPLES) {
+            return jsonToChar(stream_run_inference());
+        }
+
+        jsonResult["@type"] = "streamPartial";
+        jsonResult["text"] = g_stream.committed + g_stream.last_text;
+        return jsonToChar(jsonResult);
+    }
+
+    char *stream_stop()
+    {
+        std::lock_guard<std::mutex> lock(g_stream.mutex);
+        json jsonResult;
+
+        if (g_stream.ctx == nullptr) {
+            jsonResult["@type"] = "error";
+            jsonResult["message"] = "stream_stop: stream not started";
+            return jsonToChar(jsonResult);
+        }
+
+        // Cover whatever audio arrived after the last run.
+        if (g_stream.pcmf32.size() > g_stream.n_transcribed &&
+            g_stream.pcmf32.size() >= (size_t)WHISPER_SAMPLE_RATE / 2) {
+            stream_run_inference();
+        }
+
+        jsonResult["@type"] = "streamFinal";
+        jsonResult["text"] = g_stream.committed + g_stream.last_text;
+
+        whisper_free(g_stream.ctx);
+        g_stream.ctx = nullptr;
+        g_stream.pcmf32.clear();
+        g_stream.pcmf32.shrink_to_fit();
+        g_stream.n_transcribed = 0;
+        g_stream.committed.clear();
+        g_stream.last_text.clear();
+
+        return jsonToChar(jsonResult);
     }
 }

--- a/ios/Classes/whisper_flutter_plus.cpp
+++ b/ios/Classes/whisper_flutter_plus.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <thread>
 #include <mutex>
+#include <algorithm>
 #include <vector>
 
 #include <iostream>
@@ -406,6 +407,11 @@ extern "C"
 // past ~25 s its text is committed and the buffer restarts, keeping memory
 // and inference time bounded (a word straddling the commit boundary may be
 // clipped — acceptable for a draft).
+//
+// An RMS energy gate tracks the last voiced sample: inference only runs
+// when new voiced audio has arrived, and the decoded window is trimmed
+// shortly after the last voiced sample. Without this, whisper hallucinates
+// over trailing silence (repeating earlier text or inventing phrases).
 // ---------------------------------------------------------------------------
 
 struct whisper_stream_state
@@ -413,6 +419,8 @@ struct whisper_stream_state
     struct whisper_context *ctx = nullptr;
     std::vector<float> pcmf32;   // samples of the current window
     size_t n_transcribed = 0;    // window samples covered by the last run
+    size_t n_voiced = 0;         // end of the last chunk with speech energy
+    float noise_floor = 0.005f;  // adaptive ambient RMS estimate
     std::string committed;       // text of windows already committed
     std::string last_text;       // text of the current window's last run
     std::string language = "en";
@@ -427,6 +435,10 @@ static whisper_stream_state g_stream;
 
 static const size_t STREAM_STEP_SAMPLES   = (size_t)(1.5 * WHISPER_SAMPLE_RATE);
 static const size_t STREAM_COMMIT_SAMPLES = (size_t)(25.0 * WHISPER_SAMPLE_RATE);
+// Absolute minimum RMS for speech, regardless of the adaptive floor.
+static const float  STREAM_VOICE_RMS      = 0.0015f;
+// Decode this much audio past the last voiced sample (trailing consonants).
+static const size_t STREAM_VOICE_PAD      = (size_t)(0.2 * WHISPER_SAMPLE_RATE);
 
 // Runs whisper_full over the current window. Caller must hold g_stream.mutex.
 static json stream_run_inference()
@@ -447,8 +459,17 @@ static json stream_run_inference()
         wparams.initial_prompt = g_stream.prompt.c_str();
     }
 
+    // Trim trailing silence from the decode window; decoding it makes
+    // whisper hallucinate (repeats or invented phrases).
+    const size_t n_decode =
+        std::min(g_stream.pcmf32.size(), g_stream.n_voiced + STREAM_VOICE_PAD);
+    if (n_decode == 0) {
+        result["text"] = g_stream.committed + g_stream.last_text;
+        return result;
+    }
+
     if (whisper_full(g_stream.ctx, wparams, g_stream.pcmf32.data(),
-                     (int)g_stream.pcmf32.size()) != 0) {
+                     (int)n_decode) != 0) {
         result["@type"] = "error";
         result["message"] = "failed to process audio";
         return result;
@@ -461,13 +482,15 @@ static json stream_run_inference()
     }
 
     g_stream.last_text = text;
-    g_stream.n_transcribed = g_stream.pcmf32.size();
+    g_stream.n_transcribed = n_decode;
 
-    if (g_stream.pcmf32.size() >= STREAM_COMMIT_SAMPLES) {
+    if (n_decode >= STREAM_COMMIT_SAMPLES) {
         g_stream.committed += text;
         g_stream.last_text.clear();
-        g_stream.pcmf32.clear();
+        g_stream.pcmf32.erase(g_stream.pcmf32.begin(),
+                              g_stream.pcmf32.begin() + n_decode);
         g_stream.n_transcribed = 0;
+        g_stream.n_voiced -= std::min(g_stream.n_voiced, n_decode);
     }
 
     result["text"] = g_stream.committed + g_stream.last_text;
@@ -496,6 +519,8 @@ extern "C"
         }
         g_stream.pcmf32.clear();
         g_stream.n_transcribed = 0;
+        g_stream.n_voiced = 0;
+        g_stream.noise_floor = 0.005f;
         g_stream.committed.clear();
         g_stream.last_text.clear();
 
@@ -532,10 +557,33 @@ extern "C"
             return jsonToChar(jsonResult);
         }
         if (pcm != nullptr && n_samples > 0) {
+            double sum2 = 0.0;
+            for (int32_t i = 0; i < n_samples; ++i) {
+                sum2 += (double)pcm[i] * pcm[i];
+            }
             g_stream.pcmf32.insert(g_stream.pcmf32.end(), pcm, pcm + n_samples);
+
+            // Adaptive noise floor: falls quickly, rises slowly, so it
+            // tracks room tone without absorbing speech. A chunk is
+            // voiced only when clearly above the floor.
+            const float rms = (float)std::sqrt(sum2 / n_samples);
+            if (rms < g_stream.noise_floor) {
+                g_stream.noise_floor += 0.5f * (rms - g_stream.noise_floor);
+            } else {
+                g_stream.noise_floor += 0.0005f * (rms - g_stream.noise_floor);
+            }
+            g_stream.noise_floor = std::min(g_stream.noise_floor, 0.01f);
+            const float voice_thold =
+                std::max(2.5f * g_stream.noise_floor, STREAM_VOICE_RMS);
+            if (rms >= voice_thold) {
+                g_stream.n_voiced = g_stream.pcmf32.size();
+            }
         }
 
-        if (g_stream.pcmf32.size() - g_stream.n_transcribed >= STREAM_STEP_SAMPLES) {
+        // Run only when new *voiced* audio arrived — silence alone
+        // never triggers a decode.
+        if (g_stream.n_voiced > g_stream.n_transcribed &&
+            g_stream.pcmf32.size() - g_stream.n_transcribed >= STREAM_STEP_SAMPLES) {
             return jsonToChar(stream_run_inference());
         }
 
@@ -555,9 +603,12 @@ extern "C"
             return jsonToChar(jsonResult);
         }
 
-        // Cover whatever audio arrived after the last run.
-        if (g_stream.pcmf32.size() > g_stream.n_transcribed &&
-            g_stream.pcmf32.size() >= (size_t)WHISPER_SAMPLE_RATE / 2) {
+        // Cover voiced audio that arrived after the last run; a silent
+        // tail is dropped rather than decoded.
+        const size_t n_tail = std::min(g_stream.pcmf32.size(),
+                                       g_stream.n_voiced + STREAM_VOICE_PAD);
+        if (g_stream.n_voiced > g_stream.n_transcribed &&
+            n_tail >= (size_t)WHISPER_SAMPLE_RATE / 2) {
             stream_run_inference();
         }
 
@@ -569,6 +620,7 @@ extern "C"
         g_stream.pcmf32.clear();
         g_stream.pcmf32.shrink_to_fit();
         g_stream.n_transcribed = 0;
+        g_stream.n_voiced = 0;
         g_stream.committed.clear();
         g_stream.last_text.clear();
 

--- a/lib/src/models/requests/transcribe_request.dart
+++ b/lib/src/models/requests/transcribe_request.dart
@@ -44,6 +44,19 @@ abstract class TranscribeRequest with _$TranscribeRequest {
     /// Default `false` matches whisper.cpp's default and the behaviour
     /// of every previous version of this package.
     @Default(false) bool noContext,
+
+    /// Sets `whisper_full_params.suppress_non_speech_tokens` on the
+    /// native side.
+    ///
+    /// When `true`, whisper does not emit non-speech annotation tokens
+    /// such as `[BLANK_AUDIO]`, `[Music]`, or bracketed sound effects,
+    /// which it otherwise produces for silence and background noise.
+    /// Recommended for live transcription, where trailing silence is
+    /// common. Side effect: legitimate brackets and parentheses in
+    /// dictated text are suppressed too.
+    ///
+    /// Default `false` matches whisper.cpp's default.
+    @Default(false) bool suppressNonSpeechTokens,
   }) = _TranscribeRequest;
   const TranscribeRequest._();
 }

--- a/lib/src/models/requests/transcribe_request.freezed.dart
+++ b/lib/src/models/requests/transcribe_request.freezed.dart
@@ -53,6 +53,19 @@ mixin _$TranscribeRequest {
   /// of every previous version of this package.
   bool get noContext;
 
+  /// Sets `whisper_full_params.suppress_non_speech_tokens` on the
+  /// native side.
+  ///
+  /// When `true`, whisper does not emit non-speech annotation tokens
+  /// such as `[BLANK_AUDIO]`, `[Music]`, or bracketed sound effects,
+  /// which it otherwise produces for silence and background noise.
+  /// Recommended for live transcription, where trailing silence is
+  /// common. Side effect: legitimate brackets and parentheses in
+  /// dictated text are suppressed too.
+  ///
+  /// Default `false` matches whisper.cpp's default.
+  bool get suppressNonSpeechTokens;
+
   /// Create a copy of TranscribeRequest
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -93,7 +106,10 @@ mixin _$TranscribeRequest {
             (identical(other.initialPrompt, initialPrompt) ||
                 other.initialPrompt == initialPrompt) &&
             (identical(other.noContext, noContext) ||
-                other.noContext == noContext));
+                other.noContext == noContext) &&
+            (identical(
+                    other.suppressNonSpeechTokens, suppressNonSpeechTokens) ||
+                other.suppressNonSpeechTokens == suppressNonSpeechTokens));
   }
 
   @override
@@ -114,11 +130,12 @@ mixin _$TranscribeRequest {
       speedUp,
       realtimeStream,
       initialPrompt,
-      noContext);
+      noContext,
+      suppressNonSpeechTokens);
 
   @override
   String toString() {
-    return 'TranscribeRequest(audio: $audio, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, isRealtime: $isRealtime, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, diarize: $diarize, speedUp: $speedUp, realtimeStream: $realtimeStream, initialPrompt: $initialPrompt, noContext: $noContext)';
+    return 'TranscribeRequest(audio: $audio, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, isRealtime: $isRealtime, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, diarize: $diarize, speedUp: $speedUp, realtimeStream: $realtimeStream, initialPrompt: $initialPrompt, noContext: $noContext, suppressNonSpeechTokens: $suppressNonSpeechTokens)';
   }
 }
 
@@ -144,7 +161,8 @@ abstract mixin class $TranscribeRequestCopyWith<$Res> {
       bool speedUp,
       Stream<String>? realtimeStream,
       String? initialPrompt,
-      bool noContext});
+      bool noContext,
+      bool suppressNonSpeechTokens});
 }
 
 /// @nodoc
@@ -176,6 +194,7 @@ class _$TranscribeRequestCopyWithImpl<$Res>
     Object? realtimeStream = freezed,
     Object? initialPrompt = freezed,
     Object? noContext = null,
+    Object? suppressNonSpeechTokens = null,
   }) {
     return _then(_self.copyWith(
       audio: null == audio
@@ -241,6 +260,10 @@ class _$TranscribeRequestCopyWithImpl<$Res>
       noContext: null == noContext
           ? _self.noContext
           : noContext // ignore: cast_nullable_to_non_nullable
+              as bool,
+      suppressNonSpeechTokens: null == suppressNonSpeechTokens
+          ? _self.suppressNonSpeechTokens
+          : suppressNonSpeechTokens // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
   }
@@ -355,7 +378,8 @@ extension TranscribeRequestPatterns on TranscribeRequest {
             bool speedUp,
             Stream<String>? realtimeStream,
             String? initialPrompt,
-            bool noContext)?
+            bool noContext,
+            bool suppressNonSpeechTokens)?
         $default, {
     required TResult orElse(),
   }) {
@@ -378,7 +402,8 @@ extension TranscribeRequestPatterns on TranscribeRequest {
             _that.speedUp,
             _that.realtimeStream,
             _that.initialPrompt,
-            _that.noContext);
+            _that.noContext,
+            _that.suppressNonSpeechTokens);
       case _:
         return orElse();
     }
@@ -415,7 +440,8 @@ extension TranscribeRequestPatterns on TranscribeRequest {
             bool speedUp,
             Stream<String>? realtimeStream,
             String? initialPrompt,
-            bool noContext)
+            bool noContext,
+            bool suppressNonSpeechTokens)
         $default,
   ) {
     final _that = this;
@@ -437,7 +463,8 @@ extension TranscribeRequestPatterns on TranscribeRequest {
             _that.speedUp,
             _that.realtimeStream,
             _that.initialPrompt,
-            _that.noContext);
+            _that.noContext,
+            _that.suppressNonSpeechTokens);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -473,7 +500,8 @@ extension TranscribeRequestPatterns on TranscribeRequest {
             bool speedUp,
             Stream<String>? realtimeStream,
             String? initialPrompt,
-            bool noContext)?
+            bool noContext,
+            bool suppressNonSpeechTokens)?
         $default,
   ) {
     final _that = this;
@@ -495,7 +523,8 @@ extension TranscribeRequestPatterns on TranscribeRequest {
             _that.speedUp,
             _that.realtimeStream,
             _that.initialPrompt,
-            _that.noContext);
+            _that.noContext,
+            _that.suppressNonSpeechTokens);
       case _:
         return null;
     }
@@ -521,7 +550,8 @@ class _TranscribeRequest extends TranscribeRequest {
       this.speedUp = false,
       this.realtimeStream = null,
       this.initialPrompt = null,
-      this.noContext = false})
+      this.noContext = false,
+      this.suppressNonSpeechTokens = false})
       : super._();
 
   @override
@@ -594,6 +624,21 @@ class _TranscribeRequest extends TranscribeRequest {
   @JsonKey()
   final bool noContext;
 
+  /// Sets `whisper_full_params.suppress_non_speech_tokens` on the
+  /// native side.
+  ///
+  /// When `true`, whisper does not emit non-speech annotation tokens
+  /// such as `[BLANK_AUDIO]`, `[Music]`, or bracketed sound effects,
+  /// which it otherwise produces for silence and background noise.
+  /// Recommended for live transcription, where trailing silence is
+  /// common. Side effect: legitimate brackets and parentheses in
+  /// dictated text are suppressed too.
+  ///
+  /// Default `false` matches whisper.cpp's default.
+  @override
+  @JsonKey()
+  final bool suppressNonSpeechTokens;
+
   /// Create a copy of TranscribeRequest
   /// with the given fields replaced by the non-null parameter values.
   @override
@@ -634,7 +679,10 @@ class _TranscribeRequest extends TranscribeRequest {
             (identical(other.initialPrompt, initialPrompt) ||
                 other.initialPrompt == initialPrompt) &&
             (identical(other.noContext, noContext) ||
-                other.noContext == noContext));
+                other.noContext == noContext) &&
+            (identical(
+                    other.suppressNonSpeechTokens, suppressNonSpeechTokens) ||
+                other.suppressNonSpeechTokens == suppressNonSpeechTokens));
   }
 
   @override
@@ -655,11 +703,12 @@ class _TranscribeRequest extends TranscribeRequest {
       speedUp,
       realtimeStream,
       initialPrompt,
-      noContext);
+      noContext,
+      suppressNonSpeechTokens);
 
   @override
   String toString() {
-    return 'TranscribeRequest(audio: $audio, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, isRealtime: $isRealtime, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, diarize: $diarize, speedUp: $speedUp, realtimeStream: $realtimeStream, initialPrompt: $initialPrompt, noContext: $noContext)';
+    return 'TranscribeRequest(audio: $audio, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, isRealtime: $isRealtime, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, diarize: $diarize, speedUp: $speedUp, realtimeStream: $realtimeStream, initialPrompt: $initialPrompt, noContext: $noContext, suppressNonSpeechTokens: $suppressNonSpeechTokens)';
   }
 }
 
@@ -687,7 +736,8 @@ abstract mixin class _$TranscribeRequestCopyWith<$Res>
       bool speedUp,
       Stream<String>? realtimeStream,
       String? initialPrompt,
-      bool noContext});
+      bool noContext,
+      bool suppressNonSpeechTokens});
 }
 
 /// @nodoc
@@ -719,6 +769,7 @@ class __$TranscribeRequestCopyWithImpl<$Res>
     Object? realtimeStream = freezed,
     Object? initialPrompt = freezed,
     Object? noContext = null,
+    Object? suppressNonSpeechTokens = null,
   }) {
     return _then(_TranscribeRequest(
       audio: null == audio
@@ -784,6 +835,10 @@ class __$TranscribeRequestCopyWithImpl<$Res>
       noContext: null == noContext
           ? _self.noContext
           : noContext // ignore: cast_nullable_to_non_nullable
+              as bool,
+      suppressNonSpeechTokens: null == suppressNonSpeechTokens
+          ? _self.suppressNonSpeechTokens
+          : suppressNonSpeechTokens // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
   }

--- a/lib/src/models/requests/transcribe_request_dto.dart
+++ b/lib/src/models/requests/transcribe_request_dto.dart
@@ -32,6 +32,9 @@ abstract class TranscribeRequestDto
     @JsonKey(name: 'speed_up') required bool speedUp,
     @JsonKey(name: 'initial_prompt') String? initialPrompt,
     @JsonKey(name: 'no_context') @Default(false) bool noContext,
+    @JsonKey(name: 'suppress_non_speech_tokens')
+    @Default(false)
+    bool suppressNonSpeechTokens,
   }) = _TranscribeRequestDto;
 
   /// Convert [request] to TranscribeRequestDto with specified [modelPath]
@@ -56,6 +59,7 @@ abstract class TranscribeRequestDto
       isRealtime: request.isRealtime,
       initialPrompt: request.initialPrompt,
       noContext: request.noContext,
+      suppressNonSpeechTokens: request.suppressNonSpeechTokens,
     );
   }
   const TranscribeRequestDto._();

--- a/lib/src/models/requests/transcribe_request_dto.freezed.dart
+++ b/lib/src/models/requests/transcribe_request_dto.freezed.dart
@@ -41,6 +41,8 @@ mixin _$TranscribeRequestDto {
   String? get initialPrompt;
   @JsonKey(name: 'no_context')
   bool get noContext;
+  @JsonKey(name: 'suppress_non_speech_tokens')
+  bool get suppressNonSpeechTokens;
 
   /// Create a copy of TranscribeRequestDto
   /// with the given fields replaced by the non-null parameter values.
@@ -84,7 +86,10 @@ mixin _$TranscribeRequestDto {
             (identical(other.initialPrompt, initialPrompt) ||
                 other.initialPrompt == initialPrompt) &&
             (identical(other.noContext, noContext) ||
-                other.noContext == noContext));
+                other.noContext == noContext) &&
+            (identical(
+                    other.suppressNonSpeechTokens, suppressNonSpeechTokens) ||
+                other.suppressNonSpeechTokens == suppressNonSpeechTokens));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -106,11 +111,12 @@ mixin _$TranscribeRequestDto {
       diarize,
       speedUp,
       initialPrompt,
-      noContext);
+      noContext,
+      suppressNonSpeechTokens);
 
   @override
   String toString() {
-    return 'TranscribeRequestDto(audio: $audio, model: $model, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, isRealtime: $isRealtime, diarize: $diarize, speedUp: $speedUp, initialPrompt: $initialPrompt, noContext: $noContext)';
+    return 'TranscribeRequestDto(audio: $audio, model: $model, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, isRealtime: $isRealtime, diarize: $diarize, speedUp: $speedUp, initialPrompt: $initialPrompt, noContext: $noContext, suppressNonSpeechTokens: $suppressNonSpeechTokens)';
   }
 }
 
@@ -136,7 +142,9 @@ abstract mixin class $TranscribeRequestDtoCopyWith<$Res> {
       bool diarize,
       @JsonKey(name: 'speed_up') bool speedUp,
       @JsonKey(name: 'initial_prompt') String? initialPrompt,
-      @JsonKey(name: 'no_context') bool noContext});
+      @JsonKey(name: 'no_context') bool noContext,
+      @JsonKey(name: 'suppress_non_speech_tokens')
+      bool suppressNonSpeechTokens});
 }
 
 /// @nodoc
@@ -168,6 +176,7 @@ class _$TranscribeRequestDtoCopyWithImpl<$Res>
     Object? speedUp = null,
     Object? initialPrompt = freezed,
     Object? noContext = null,
+    Object? suppressNonSpeechTokens = null,
   }) {
     return _then(_self.copyWith(
       audio: null == audio
@@ -233,6 +242,10 @@ class _$TranscribeRequestDtoCopyWithImpl<$Res>
       noContext: null == noContext
           ? _self.noContext
           : noContext // ignore: cast_nullable_to_non_nullable
+              as bool,
+      suppressNonSpeechTokens: null == suppressNonSpeechTokens
+          ? _self.suppressNonSpeechTokens
+          : suppressNonSpeechTokens // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
   }
@@ -347,7 +360,9 @@ extension TranscribeRequestDtoPatterns on TranscribeRequestDto {
             bool diarize,
             @JsonKey(name: 'speed_up') bool speedUp,
             @JsonKey(name: 'initial_prompt') String? initialPrompt,
-            @JsonKey(name: 'no_context') bool noContext)?
+            @JsonKey(name: 'no_context') bool noContext,
+            @JsonKey(name: 'suppress_non_speech_tokens')
+            bool suppressNonSpeechTokens)?
         $default, {
     required TResult orElse(),
   }) {
@@ -370,7 +385,8 @@ extension TranscribeRequestDtoPatterns on TranscribeRequestDto {
             _that.diarize,
             _that.speedUp,
             _that.initialPrompt,
-            _that.noContext);
+            _that.noContext,
+            _that.suppressNonSpeechTokens);
       case _:
         return orElse();
     }
@@ -407,7 +423,9 @@ extension TranscribeRequestDtoPatterns on TranscribeRequestDto {
             bool diarize,
             @JsonKey(name: 'speed_up') bool speedUp,
             @JsonKey(name: 'initial_prompt') String? initialPrompt,
-            @JsonKey(name: 'no_context') bool noContext)
+            @JsonKey(name: 'no_context') bool noContext,
+            @JsonKey(name: 'suppress_non_speech_tokens')
+            bool suppressNonSpeechTokens)
         $default,
   ) {
     final _that = this;
@@ -429,7 +447,8 @@ extension TranscribeRequestDtoPatterns on TranscribeRequestDto {
             _that.diarize,
             _that.speedUp,
             _that.initialPrompt,
-            _that.noContext);
+            _that.noContext,
+            _that.suppressNonSpeechTokens);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -465,7 +484,9 @@ extension TranscribeRequestDtoPatterns on TranscribeRequestDto {
             bool diarize,
             @JsonKey(name: 'speed_up') bool speedUp,
             @JsonKey(name: 'initial_prompt') String? initialPrompt,
-            @JsonKey(name: 'no_context') bool noContext)?
+            @JsonKey(name: 'no_context') bool noContext,
+            @JsonKey(name: 'suppress_non_speech_tokens')
+            bool suppressNonSpeechTokens)?
         $default,
   ) {
     final _that = this;
@@ -487,7 +508,8 @@ extension TranscribeRequestDtoPatterns on TranscribeRequestDto {
             _that.diarize,
             _that.speedUp,
             _that.initialPrompt,
-            _that.noContext);
+            _that.noContext,
+            _that.suppressNonSpeechTokens);
       case _:
         return null;
     }
@@ -513,7 +535,9 @@ class _TranscribeRequestDto extends TranscribeRequestDto {
       required this.diarize,
       @JsonKey(name: 'speed_up') required this.speedUp,
       @JsonKey(name: 'initial_prompt') this.initialPrompt,
-      @JsonKey(name: 'no_context') this.noContext = false})
+      @JsonKey(name: 'no_context') this.noContext = false,
+      @JsonKey(name: 'suppress_non_speech_tokens')
+      this.suppressNonSpeechTokens = false})
       : super._();
   factory _TranscribeRequestDto.fromJson(Map<String, dynamic> json) =>
       _$TranscribeRequestDtoFromJson(json);
@@ -561,6 +585,9 @@ class _TranscribeRequestDto extends TranscribeRequestDto {
   @override
   @JsonKey(name: 'no_context')
   final bool noContext;
+  @override
+  @JsonKey(name: 'suppress_non_speech_tokens')
+  final bool suppressNonSpeechTokens;
 
   /// Create a copy of TranscribeRequestDto
   /// with the given fields replaced by the non-null parameter values.
@@ -609,7 +636,10 @@ class _TranscribeRequestDto extends TranscribeRequestDto {
             (identical(other.initialPrompt, initialPrompt) ||
                 other.initialPrompt == initialPrompt) &&
             (identical(other.noContext, noContext) ||
-                other.noContext == noContext));
+                other.noContext == noContext) &&
+            (identical(
+                    other.suppressNonSpeechTokens, suppressNonSpeechTokens) ||
+                other.suppressNonSpeechTokens == suppressNonSpeechTokens));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -631,11 +661,12 @@ class _TranscribeRequestDto extends TranscribeRequestDto {
       diarize,
       speedUp,
       initialPrompt,
-      noContext);
+      noContext,
+      suppressNonSpeechTokens);
 
   @override
   String toString() {
-    return 'TranscribeRequestDto(audio: $audio, model: $model, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, isRealtime: $isRealtime, diarize: $diarize, speedUp: $speedUp, initialPrompt: $initialPrompt, noContext: $noContext)';
+    return 'TranscribeRequestDto(audio: $audio, model: $model, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, isRealtime: $isRealtime, diarize: $diarize, speedUp: $speedUp, initialPrompt: $initialPrompt, noContext: $noContext, suppressNonSpeechTokens: $suppressNonSpeechTokens)';
   }
 }
 
@@ -663,7 +694,9 @@ abstract mixin class _$TranscribeRequestDtoCopyWith<$Res>
       bool diarize,
       @JsonKey(name: 'speed_up') bool speedUp,
       @JsonKey(name: 'initial_prompt') String? initialPrompt,
-      @JsonKey(name: 'no_context') bool noContext});
+      @JsonKey(name: 'no_context') bool noContext,
+      @JsonKey(name: 'suppress_non_speech_tokens')
+      bool suppressNonSpeechTokens});
 }
 
 /// @nodoc
@@ -695,6 +728,7 @@ class __$TranscribeRequestDtoCopyWithImpl<$Res>
     Object? speedUp = null,
     Object? initialPrompt = freezed,
     Object? noContext = null,
+    Object? suppressNonSpeechTokens = null,
   }) {
     return _then(_TranscribeRequestDto(
       audio: null == audio
@@ -760,6 +794,10 @@ class __$TranscribeRequestDtoCopyWithImpl<$Res>
       noContext: null == noContext
           ? _self.noContext
           : noContext // ignore: cast_nullable_to_non_nullable
+              as bool,
+      suppressNonSpeechTokens: null == suppressNonSpeechTokens
+          ? _self.suppressNonSpeechTokens
+          : suppressNonSpeechTokens // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
   }

--- a/lib/src/models/requests/transcribe_request_dto.g.dart
+++ b/lib/src/models/requests/transcribe_request_dto.g.dart
@@ -25,6 +25,8 @@ _TranscribeRequestDto _$TranscribeRequestDtoFromJson(
       speedUp: json['speed_up'] as bool,
       initialPrompt: json['initial_prompt'] as String?,
       noContext: json['no_context'] as bool? ?? false,
+      suppressNonSpeechTokens:
+          json['suppress_non_speech_tokens'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$TranscribeRequestDtoToJson(
@@ -46,4 +48,5 @@ Map<String, dynamic> _$TranscribeRequestDtoToJson(
       'speed_up': instance.speedUp,
       'initial_prompt': instance.initialPrompt,
       'no_context': instance.noContext,
+      'suppress_non_speech_tokens': instance.suppressNonSpeechTokens,
     };

--- a/lib/src/whisper.dart
+++ b/lib/src/whisper.dart
@@ -56,6 +56,8 @@ class Whisper {
           json.decode(res.toDartString()) as Map<String, dynamic>;
 
       malloc.free(data);
+      // Native responses are malloc'd specifically so this free is valid.
+      malloc.free(res);
       return result;
     });
   }

--- a/lib/src/whisper_controller.dart
+++ b/lib/src/whisper_controller.dart
@@ -27,12 +27,20 @@ class WhisperController {
   /// and `stop()` returns the full transcript.
   ///
   /// Unlike [transcribe], the model is loaded once for the whole session.
+  /// The `gate*` parameters tune the native energy gate that keeps silence
+  /// away from the decoder: a chunk counts as voiced when its RMS exceeds
+  /// `max(gateVoiceRatio * noiseFloor, gateRmsMin)`, where the adaptive
+  /// noise floor is capped at [gateNoiseFloorCap]. Raise the cap for loud
+  /// environments; lower [gateRmsMin] for very quiet speakers.
   Future<WhisperLiveSession> transcribeLive({
     required WhisperModel model,
     required Stream<Uint8List> pcm16Stream,
     String lang = 'en',
     String? initialPrompt,
     bool suppressNonSpeechTokens = false,
+    double gateRmsMin = 0.0015,
+    double gateVoiceRatio = 2.5,
+    double gateNoiseFloorCap = 0.01,
   }) async {
     await initModel(model);
 
@@ -41,12 +49,18 @@ class WhisperController {
       lang: lang,
       initialPrompt: initialPrompt,
       suppressNonSpeechTokens: suppressNonSpeechTokens,
+      gateRmsMin: gateRmsMin,
+      gateVoiceRatio: gateVoiceRatio,
+      gateNoiseFloorCap: gateNoiseFloorCap,
     );
 
     pcm16Stream.listen(
       session.feed,
       onDone: session.stop,
-      onError: (Object _) => session.stop(),
+      onError: (Object e) {
+        debugPrint('transcribeLive: audio stream error: $e');
+        session.stop();
+      },
     );
 
     return session;

--- a/lib/src/whisper_controller.dart
+++ b/lib/src/whisper_controller.dart
@@ -32,6 +32,7 @@ class WhisperController {
     required Stream<Uint8List> pcm16Stream,
     String lang = 'en',
     String? initialPrompt,
+    bool suppressNonSpeechTokens = false,
   }) async {
     await initModel(model);
 
@@ -39,6 +40,7 @@ class WhisperController {
       modelPath: _modelPath,
       lang: lang,
       initialPrompt: initialPrompt,
+      suppressNonSpeechTokens: suppressNonSpeechTokens,
     );
 
     pcm16Stream.listen(
@@ -57,6 +59,7 @@ class WhisperController {
     bool diarize = false,
     String? initialPrompt,
     bool noContext = false,
+    bool suppressNonSpeechTokens = false,
   }) async {
     await initModel(model);
 
@@ -78,6 +81,7 @@ class WhisperController {
           diarize: diarize,
           initialPrompt: initialPrompt,
           noContext: noContext,
+          suppressNonSpeechTokens: suppressNonSpeechTokens,
         ),
         modelPath: _modelPath,
       );

--- a/lib/src/whisper_controller.dart
+++ b/lib/src/whisper_controller.dart
@@ -5,6 +5,7 @@ import 'package:whisper_ggml/src/models/whisper_model.dart';
 
 import 'models/whisper_result.dart';
 import 'whisper.dart';
+import 'whisper_live.dart';
 
 class WhisperController {
   String _modelPath = '';
@@ -13,6 +14,40 @@ class WhisperController {
   Future<void> initModel(WhisperModel model) async {
     _dir ??= await getModelDir();
     _modelPath = '$_dir/ggml-${model.modelName}.bin';
+  }
+
+  /// Start a live transcription session.
+  ///
+  /// [pcm16Stream] must produce 16 kHz mono little-endian PCM16 audio (e.g.
+  /// the `record` package's `startStream` with
+  /// `RecordConfig(encoder: AudioEncoder.pcm16bits, sampleRate: 16000,
+  /// numChannels: 1)`). Partial transcripts are emitted on
+  /// [WhisperLiveSession.partials] while audio flows; when [pcm16Stream]
+  /// closes (or [WhisperLiveSession.stop] is called) the session finalizes
+  /// and `stop()` returns the full transcript.
+  ///
+  /// Unlike [transcribe], the model is loaded once for the whole session.
+  Future<WhisperLiveSession> transcribeLive({
+    required WhisperModel model,
+    required Stream<Uint8List> pcm16Stream,
+    String lang = 'en',
+    String? initialPrompt,
+  }) async {
+    await initModel(model);
+
+    final WhisperLiveSession session = await startWhisperLiveSession(
+      modelPath: _modelPath,
+      lang: lang,
+      initialPrompt: initialPrompt,
+    );
+
+    pcm16Stream.listen(
+      session.feed,
+      onDone: session.stop,
+      onError: (Object _) => session.stop(),
+    );
+
+    return session;
   }
 
   Future<TranscribeResult?> transcribe({

--- a/lib/src/whisper_live.dart
+++ b/lib/src/whisper_live.dart
@@ -58,6 +58,9 @@ Future<WhisperLiveSession> startWhisperLiveSession({
   String? initialPrompt,
   bool suppressNonSpeechTokens = false,
   int threads = 4,
+  double gateRmsMin = 0.0015,
+  double gateVoiceRatio = 2.5,
+  double gateNoiseFloorCap = 0.01,
 }) async {
   final ReceivePort fromWorker = ReceivePort();
   final Isolate worker =
@@ -68,6 +71,8 @@ Future<WhisperLiveSession> startWhisperLiveSession({
   final Completer<void> started = Completer<void>();
   late final WhisperLiveSession session;
 
+  String lastText = '';
+
   fromWorker.listen((dynamic message) {
     final List<dynamic> msg = message as List<dynamic>;
     switch (msg[0] as String) {
@@ -76,7 +81,8 @@ Future<WhisperLiveSession> startWhisperLiveSession({
       case 'started':
         started.complete();
       case 'partial':
-        if (!partials.isClosed) partials.add(msg[1] as String);
+        lastText = msg[1] as String;
+        if (!partials.isClosed) partials.add(lastText);
       case 'final':
         if (!partials.isClosed) partials.close();
         session._final.complete(msg[1] as String);
@@ -87,7 +93,16 @@ Future<WhisperLiveSession> startWhisperLiveSession({
         if (!started.isCompleted) {
           started.completeError(error);
         } else if (!session._final.isCompleted) {
-          partials.addError(error);
+          // A mid-session native error is fatal: surface it on [partials],
+          // then finalize with the last known text so stop() never hangs.
+          if (!partials.isClosed) {
+            partials
+              ..addError(error)
+              ..close();
+          }
+          session._final.complete(lastText);
+          fromWorker.close();
+          session._worker.kill();
         }
     }
   });
@@ -103,6 +118,9 @@ Future<WhisperLiveSession> startWhisperLiveSession({
       'is_translate': translate,
       'threads': threads,
       'suppress_non_speech_tokens': suppressNonSpeechTokens,
+      'gate_rms_min': gateRmsMin,
+      'gate_voice_ratio': gateVoiceRatio,
+      'gate_floor_cap': gateNoiseFloorCap,
       if (initialPrompt != null && initialPrompt.isNotEmpty)
         'initial_prompt': initialPrompt,
     }),
@@ -112,6 +130,8 @@ Future<WhisperLiveSession> startWhisperLiveSession({
     await started.future;
   } catch (_) {
     worker.kill(priority: Isolate.immediate);
+    fromWorker.close();
+    await partials.close();
     rethrow;
   }
   return session;
@@ -121,6 +141,11 @@ Future<WhisperLiveSession> startWhisperLiveSession({
 /// isolate. Messages arriving while inference runs simply queue in the
 /// mailbox; the native side only re-runs inference once enough new audio
 /// has accumulated, so queued chunks drain quickly.
+///
+/// Note: backpressure is bounded only by decode speed. On devices where the
+/// model decodes slower than real time, the mailbox and the native window
+/// grow and partial latency drifts behind the audio. If that becomes a
+/// target, cap the window or surface an "audio seconds behind" metric.
 void _liveWorker(SendPort toMain) {
   final DynamicLibrary lib = Platform.isAndroid
       ? DynamicLibrary.open('libwhisper.so')
@@ -136,9 +161,15 @@ void _liveWorker(SendPort toMain) {
   toMain.send(['ready', inbox.sendPort]);
 
   String lastPartial = '';
+  int pendingByte = -1; // odd trailing byte carried into the next chunk
 
-  Map<String, dynamic> parse(Pointer<Utf8> res) =>
-      json.decode(res.toDartString()) as Map<String, dynamic>;
+  Map<String, dynamic> parse(Pointer<Utf8> res) {
+    final Map<String, dynamic> result =
+        json.decode(res.toDartString()) as Map<String, dynamic>;
+    // The native side allocates responses with malloc for exactly this free.
+    malloc.free(res);
+    return result;
+  }
 
   inbox.listen((dynamic message) {
     final List<dynamic> msg = message as List<dynamic>;
@@ -154,11 +185,27 @@ void _liveWorker(SendPort toMain) {
         }
       case 'feed':
         Uint8List bytes = msg[1] as Uint8List;
-        // asInt16List requires an even byte offset into the underlying
-        // buffer; chunks that arrive as odd-offset views must be copied.
-        if (bytes.offsetInBytes.isOdd) {
-          bytes = Uint8List.fromList(bytes);
+        // Normalize the chunk: asInt16List needs an even byte offset, and an
+        // odd-length chunk would shift every following sample by one byte
+        // (silent corruption), so the trailing byte is carried into the next
+        // chunk instead.
+        if (pendingByte >= 0 ||
+            bytes.offsetInBytes.isOdd ||
+            bytes.length.isOdd) {
+          final Uint8List merged =
+              Uint8List(bytes.length + (pendingByte >= 0 ? 1 : 0));
+          int offset = 0;
+          if (pendingByte >= 0) merged[offset++] = pendingByte;
+          merged.setRange(offset, offset + bytes.length, bytes);
+          if (merged.length.isOdd) {
+            pendingByte = merged.last;
+            bytes = Uint8List.sublistView(merged, 0, merged.length - 1);
+          } else {
+            pendingByte = -1;
+            bytes = merged;
+          }
         }
+        if (bytes.isEmpty) return;
         final Int16List samples =
             bytes.buffer.asInt16List(bytes.offsetInBytes, bytes.length ~/ 2);
         final Pointer<Float> pcm = malloc.allocate<Float>(

--- a/lib/src/whisper_live.dart
+++ b/lib/src/whisper_live.dart
@@ -56,6 +56,7 @@ Future<WhisperLiveSession> startWhisperLiveSession({
   String lang = 'en',
   bool translate = false,
   String? initialPrompt,
+  bool suppressNonSpeechTokens = false,
   int threads = 4,
 }) async {
   final ReceivePort fromWorker = ReceivePort();
@@ -101,6 +102,7 @@ Future<WhisperLiveSession> startWhisperLiveSession({
       'language': lang,
       'is_translate': translate,
       'threads': threads,
+      'suppress_non_speech_tokens': suppressNonSpeechTokens,
       if (initialPrompt != null && initialPrompt.isNotEmpty)
         'initial_prompt': initialPrompt,
     }),

--- a/lib/src/whisper_live.dart
+++ b/lib/src/whisper_live.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ffi';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:ffi/ffi.dart';
+import 'package:universal_io/io.dart';
+
+/// Native streaming bindings.
+typedef _StreamStartNative = Pointer<Utf8> Function(Pointer<Utf8> body);
+typedef _StreamFeedNative = Pointer<Utf8> Function(
+    Pointer<Float> pcm, Int32 nSamples);
+typedef _StreamFeedDart = Pointer<Utf8> Function(Pointer<Float> pcm, int n);
+typedef _StreamStopNative = Pointer<Utf8> Function();
+
+/// A running live transcription session.
+///
+/// Obtain one from `WhisperController.transcribeLive`. Listen to [partials]
+/// for progressively refined transcripts while audio is being fed, and call
+/// [stop] to get the final text and release the native context.
+class WhisperLiveSession {
+  WhisperLiveSession._(this._worker, this._toWorker, this._partials);
+
+  final Isolate _worker;
+  final SendPort _toWorker;
+  final StreamController<String> _partials;
+  final Completer<String> _final = Completer<String>();
+  bool _stopped = false;
+
+  /// Progressively refined transcripts of the audio fed so far. Each event
+  /// replaces the previous one (it is the full text, not a delta).
+  Stream<String> get partials => _partials.stream;
+
+  /// Feed 16 kHz mono PCM16 (little-endian) audio bytes.
+  void feed(Uint8List pcm16Bytes) {
+    if (_stopped) return;
+    _toWorker.send(['feed', pcm16Bytes]);
+  }
+
+  /// Finish the session: transcribe any remaining audio, release the native
+  /// context, and return the final transcript.
+  Future<String> stop() {
+    if (!_stopped) {
+      _stopped = true;
+      _toWorker.send(const ['stop']);
+    }
+    return _final.future;
+  }
+}
+
+/// Spawns the worker isolate and starts a native stream. Internal API used by
+/// `WhisperController.transcribeLive`.
+Future<WhisperLiveSession> startWhisperLiveSession({
+  required String modelPath,
+  String lang = 'en',
+  bool translate = false,
+  String? initialPrompt,
+  int threads = 4,
+}) async {
+  final ReceivePort fromWorker = ReceivePort();
+  final Isolate worker =
+      await Isolate.spawn(_liveWorker, fromWorker.sendPort);
+
+  final StreamController<String> partials = StreamController<String>();
+  final Completer<SendPort> ready = Completer<SendPort>();
+  final Completer<void> started = Completer<void>();
+  late final WhisperLiveSession session;
+
+  fromWorker.listen((dynamic message) {
+    final List<dynamic> msg = message as List<dynamic>;
+    switch (msg[0] as String) {
+      case 'ready':
+        ready.complete(msg[1] as SendPort);
+      case 'started':
+        started.complete();
+      case 'partial':
+        if (!partials.isClosed) partials.add(msg[1] as String);
+      case 'final':
+        if (!partials.isClosed) partials.close();
+        session._final.complete(msg[1] as String);
+        fromWorker.close();
+        session._worker.kill();
+      case 'error':
+        final error = Exception(msg[1] as String);
+        if (!started.isCompleted) {
+          started.completeError(error);
+        } else if (!session._final.isCompleted) {
+          partials.addError(error);
+        }
+    }
+  });
+
+  final SendPort toWorker = await ready.future;
+  session = WhisperLiveSession._(worker, toWorker, partials);
+
+  toWorker.send([
+    'start',
+    json.encode({
+      'model': modelPath,
+      'language': lang,
+      'is_translate': translate,
+      'threads': threads,
+      if (initialPrompt != null && initialPrompt.isNotEmpty)
+        'initial_prompt': initialPrompt,
+    }),
+  ]);
+
+  try {
+    await started.future;
+  } catch (_) {
+    worker.kill(priority: Isolate.immediate);
+    rethrow;
+  }
+  return session;
+}
+
+/// Worker isolate: owns all FFI calls so whisper_full never blocks the UI
+/// isolate. Messages arriving while inference runs simply queue in the
+/// mailbox; the native side only re-runs inference once enough new audio
+/// has accumulated, so queued chunks drain quickly.
+void _liveWorker(SendPort toMain) {
+  final DynamicLibrary lib = Platform.isAndroid
+      ? DynamicLibrary.open('libwhisper.so')
+      : DynamicLibrary.process();
+
+  final start =
+      lib.lookupFunction<_StreamStartNative, _StreamStartNative>('stream_start');
+  final feed = lib.lookupFunction<_StreamFeedNative, _StreamFeedDart>('stream_feed');
+  final stopFn =
+      lib.lookupFunction<_StreamStopNative, _StreamStopNative>('stream_stop');
+
+  final ReceivePort inbox = ReceivePort();
+  toMain.send(['ready', inbox.sendPort]);
+
+  String lastPartial = '';
+
+  Map<String, dynamic> parse(Pointer<Utf8> res) =>
+      json.decode(res.toDartString()) as Map<String, dynamic>;
+
+  inbox.listen((dynamic message) {
+    final List<dynamic> msg = message as List<dynamic>;
+    switch (msg[0] as String) {
+      case 'start':
+        final Pointer<Utf8> body = (msg[1] as String).toNativeUtf8();
+        final Map<String, dynamic> result = parse(start(body));
+        malloc.free(body);
+        if (result['@type'] == 'error') {
+          toMain.send(['error', result['message']]);
+        } else {
+          toMain.send(const ['started']);
+        }
+      case 'feed':
+        Uint8List bytes = msg[1] as Uint8List;
+        // asInt16List requires an even byte offset into the underlying
+        // buffer; chunks that arrive as odd-offset views must be copied.
+        if (bytes.offsetInBytes.isOdd) {
+          bytes = Uint8List.fromList(bytes);
+        }
+        final Int16List samples =
+            bytes.buffer.asInt16List(bytes.offsetInBytes, bytes.length ~/ 2);
+        final Pointer<Float> pcm = malloc.allocate<Float>(
+          samples.length * sizeOf<Float>(),
+        );
+        final Float32List dest = pcm.asTypedList(samples.length);
+        for (int i = 0; i < samples.length; i++) {
+          dest[i] = samples[i] / 32768.0;
+        }
+        final Map<String, dynamic> result = parse(feed(pcm, samples.length));
+        malloc.free(pcm);
+        if (result['@type'] == 'error') {
+          toMain.send(['error', result['message']]);
+        } else {
+          final String text = result['text'] as String? ?? '';
+          if (text != lastPartial) {
+            lastPartial = text;
+            toMain.send(['partial', text]);
+          }
+        }
+      case 'stop':
+        final Map<String, dynamic> result = parse(stopFn());
+        toMain.send([
+          'final',
+          result['@type'] == 'error' ? lastPartial : result['text'] as String,
+        ]);
+        inbox.close();
+    }
+  });
+}

--- a/lib/whisper_ggml.dart
+++ b/lib/whisper_ggml.dart
@@ -2,4 +2,5 @@ export 'src/models/whisper_model.dart';
 export 'src/whisper.dart';
 export 'src/whisper_audio_convert.dart';
 export 'src/whisper_controller.dart';
+export 'src/whisper_live.dart' show WhisperLiveSession;
 export 'src/models/_models.dart';

--- a/macos/Classes/whisper_ggml.cpp
+++ b/macos/Classes/whisper_ggml.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <thread>
 #include <mutex>
+#include <algorithm>
 #include <vector>
 
 #include <iostream>
@@ -409,6 +410,11 @@ extern "C"
 // past ~25 s its text is committed and the buffer restarts, keeping memory
 // and inference time bounded (a word straddling the commit boundary may be
 // clipped — acceptable for a draft).
+//
+// An RMS energy gate tracks the last voiced sample: inference only runs
+// when new voiced audio has arrived, and the decoded window is trimmed
+// shortly after the last voiced sample. Without this, whisper hallucinates
+// over trailing silence (repeating earlier text or inventing phrases).
 // ---------------------------------------------------------------------------
 
 struct whisper_stream_state
@@ -416,6 +422,8 @@ struct whisper_stream_state
     struct whisper_context *ctx = nullptr;
     std::vector<float> pcmf32;   // samples of the current window
     size_t n_transcribed = 0;    // window samples covered by the last run
+    size_t n_voiced = 0;         // end of the last chunk with speech energy
+    float noise_floor = 0.005f;  // adaptive ambient RMS estimate
     std::string committed;       // text of windows already committed
     std::string last_text;       // text of the current window's last run
     std::string language = "en";
@@ -430,6 +438,10 @@ static whisper_stream_state g_stream;
 
 static const size_t STREAM_STEP_SAMPLES   = (size_t)(1.5 * WHISPER_SAMPLE_RATE);
 static const size_t STREAM_COMMIT_SAMPLES = (size_t)(25.0 * WHISPER_SAMPLE_RATE);
+// Absolute minimum RMS for speech, regardless of the adaptive floor.
+static const float  STREAM_VOICE_RMS      = 0.0015f;
+// Decode this much audio past the last voiced sample (trailing consonants).
+static const size_t STREAM_VOICE_PAD      = (size_t)(0.2 * WHISPER_SAMPLE_RATE);
 
 // Runs whisper_full over the current window. Caller must hold g_stream.mutex.
 static json stream_run_inference()
@@ -450,8 +462,17 @@ static json stream_run_inference()
         wparams.initial_prompt = g_stream.prompt.c_str();
     }
 
+    // Trim trailing silence from the decode window; decoding it makes
+    // whisper hallucinate (repeats or invented phrases).
+    const size_t n_decode =
+        std::min(g_stream.pcmf32.size(), g_stream.n_voiced + STREAM_VOICE_PAD);
+    if (n_decode == 0) {
+        result["text"] = g_stream.committed + g_stream.last_text;
+        return result;
+    }
+
     if (whisper_full(g_stream.ctx, wparams, g_stream.pcmf32.data(),
-                     (int)g_stream.pcmf32.size()) != 0) {
+                     (int)n_decode) != 0) {
         result["@type"] = "error";
         result["message"] = "failed to process audio";
         return result;
@@ -464,13 +485,15 @@ static json stream_run_inference()
     }
 
     g_stream.last_text = text;
-    g_stream.n_transcribed = g_stream.pcmf32.size();
+    g_stream.n_transcribed = n_decode;
 
-    if (g_stream.pcmf32.size() >= STREAM_COMMIT_SAMPLES) {
+    if (n_decode >= STREAM_COMMIT_SAMPLES) {
         g_stream.committed += text;
         g_stream.last_text.clear();
-        g_stream.pcmf32.clear();
+        g_stream.pcmf32.erase(g_stream.pcmf32.begin(),
+                              g_stream.pcmf32.begin() + n_decode);
         g_stream.n_transcribed = 0;
+        g_stream.n_voiced -= std::min(g_stream.n_voiced, n_decode);
     }
 
     result["text"] = g_stream.committed + g_stream.last_text;
@@ -499,6 +522,8 @@ extern "C"
         }
         g_stream.pcmf32.clear();
         g_stream.n_transcribed = 0;
+        g_stream.n_voiced = 0;
+        g_stream.noise_floor = 0.005f;
         g_stream.committed.clear();
         g_stream.last_text.clear();
 
@@ -535,10 +560,33 @@ extern "C"
             return jsonToChar(jsonResult);
         }
         if (pcm != nullptr && n_samples > 0) {
+            double sum2 = 0.0;
+            for (int32_t i = 0; i < n_samples; ++i) {
+                sum2 += (double)pcm[i] * pcm[i];
+            }
             g_stream.pcmf32.insert(g_stream.pcmf32.end(), pcm, pcm + n_samples);
+
+            // Adaptive noise floor: falls quickly, rises slowly, so it
+            // tracks room tone without absorbing speech. A chunk is
+            // voiced only when clearly above the floor.
+            const float rms = (float)std::sqrt(sum2 / n_samples);
+            if (rms < g_stream.noise_floor) {
+                g_stream.noise_floor += 0.5f * (rms - g_stream.noise_floor);
+            } else {
+                g_stream.noise_floor += 0.0005f * (rms - g_stream.noise_floor);
+            }
+            g_stream.noise_floor = std::min(g_stream.noise_floor, 0.01f);
+            const float voice_thold =
+                std::max(2.5f * g_stream.noise_floor, STREAM_VOICE_RMS);
+            if (rms >= voice_thold) {
+                g_stream.n_voiced = g_stream.pcmf32.size();
+            }
         }
 
-        if (g_stream.pcmf32.size() - g_stream.n_transcribed >= STREAM_STEP_SAMPLES) {
+        // Run only when new *voiced* audio arrived — silence alone
+        // never triggers a decode.
+        if (g_stream.n_voiced > g_stream.n_transcribed &&
+            g_stream.pcmf32.size() - g_stream.n_transcribed >= STREAM_STEP_SAMPLES) {
             return jsonToChar(stream_run_inference());
         }
 
@@ -558,9 +606,12 @@ extern "C"
             return jsonToChar(jsonResult);
         }
 
-        // Cover whatever audio arrived after the last run.
-        if (g_stream.pcmf32.size() > g_stream.n_transcribed &&
-            g_stream.pcmf32.size() >= (size_t)WHISPER_SAMPLE_RATE / 2) {
+        // Cover voiced audio that arrived after the last run; a silent
+        // tail is dropped rather than decoded.
+        const size_t n_tail = std::min(g_stream.pcmf32.size(),
+                                       g_stream.n_voiced + STREAM_VOICE_PAD);
+        if (g_stream.n_voiced > g_stream.n_transcribed &&
+            n_tail >= (size_t)WHISPER_SAMPLE_RATE / 2) {
             stream_run_inference();
         }
 
@@ -572,6 +623,7 @@ extern "C"
         g_stream.pcmf32.clear();
         g_stream.pcmf32.shrink_to_fit();
         g_stream.n_transcribed = 0;
+        g_stream.n_voiced = 0;
         g_stream.committed.clear();
         g_stream.last_text.clear();
 

--- a/macos/Classes/whisper_ggml.cpp
+++ b/macos/Classes/whisper_ggml.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <string>
 #include <thread>
+#include <mutex>
 #include <vector>
 
 #include <iostream>
@@ -381,5 +382,189 @@ extern "C"
         jsonBody["@type"] = "al";
         print(transcribe(jsonBody).dump());
         return 0;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Live (streaming) transcription.
+//
+// Unlike request()/transcribe(), which load the model on every call, a stream
+// keeps one whisper_context alive for the whole session:
+//
+//   stream_start(json)          -> loads the model, resets state
+//   stream_feed(pcm, n)         -> appends 16 kHz mono float samples; re-runs
+//                                  inference when >= ~1.5 s of new audio has
+//                                  accumulated and returns the partial text
+//   stream_stop()               -> final text, frees the context
+//
+// Partials re-decode the whole current window with no_context = true, so a
+// wrong early partial does not condition later ones. When the window grows
+// past ~25 s its text is committed and the buffer restarts, keeping memory
+// and inference time bounded (a word straddling the commit boundary may be
+// clipped — acceptable for a draft).
+// ---------------------------------------------------------------------------
+
+struct whisper_stream_state
+{
+    struct whisper_context *ctx = nullptr;
+    std::vector<float> pcmf32;   // samples of the current window
+    size_t n_transcribed = 0;    // window samples covered by the last run
+    std::string committed;       // text of windows already committed
+    std::string last_text;       // text of the current window's last run
+    std::string language = "en";
+    std::string prompt;
+    int n_threads = 4;
+    bool translate = false;
+    std::mutex mutex;
+};
+
+static whisper_stream_state g_stream;
+
+static const size_t STREAM_STEP_SAMPLES   = (size_t)(1.5 * WHISPER_SAMPLE_RATE);
+static const size_t STREAM_COMMIT_SAMPLES = (size_t)(25.0 * WHISPER_SAMPLE_RATE);
+
+// Runs whisper_full over the current window. Caller must hold g_stream.mutex.
+static json stream_run_inference()
+{
+    json result;
+    result["@type"] = "streamPartial";
+
+    whisper_full_params wparams = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+    wparams.print_realtime   = false;
+    wparams.print_progress   = false;
+    wparams.print_timestamps = false;
+    wparams.translate        = g_stream.translate;
+    wparams.language         = g_stream.language.c_str();
+    wparams.n_threads        = g_stream.n_threads;
+    wparams.no_context       = true;
+    if (!g_stream.prompt.empty()) {
+        wparams.initial_prompt = g_stream.prompt.c_str();
+    }
+
+    if (whisper_full(g_stream.ctx, wparams, g_stream.pcmf32.data(),
+                     (int)g_stream.pcmf32.size()) != 0) {
+        result["@type"] = "error";
+        result["message"] = "failed to process audio";
+        return result;
+    }
+
+    std::string text;
+    const int n_segments = whisper_full_n_segments(g_stream.ctx);
+    for (int i = 0; i < n_segments; ++i) {
+        text += whisper_full_get_segment_text(g_stream.ctx, i);
+    }
+
+    g_stream.last_text = text;
+    g_stream.n_transcribed = g_stream.pcmf32.size();
+
+    if (g_stream.pcmf32.size() >= STREAM_COMMIT_SAMPLES) {
+        g_stream.committed += text;
+        g_stream.last_text.clear();
+        g_stream.pcmf32.clear();
+        g_stream.n_transcribed = 0;
+    }
+
+    result["text"] = g_stream.committed + g_stream.last_text;
+    return result;
+}
+
+extern "C"
+{
+    // body: {"model": path, "language": "en", "threads": 4,
+    //        "is_translate": false, "initial_prompt": "..."}
+    char *stream_start(char *body)
+    {
+        std::lock_guard<std::mutex> lock(g_stream.mutex);
+        json jsonResult;
+
+        json jsonBody = json::parse(body, nullptr, false);
+        if (jsonBody.is_discarded() || !jsonBody.contains("model")) {
+            jsonResult["@type"] = "error";
+            jsonResult["message"] = "stream_start: invalid request body";
+            return jsonToChar(jsonResult);
+        }
+
+        if (g_stream.ctx != nullptr) {
+            whisper_free(g_stream.ctx);
+            g_stream.ctx = nullptr;
+        }
+        g_stream.pcmf32.clear();
+        g_stream.n_transcribed = 0;
+        g_stream.committed.clear();
+        g_stream.last_text.clear();
+
+        g_stream.language  = jsonBody.value("language", "en");
+        g_stream.n_threads = jsonBody.value("threads", 4);
+        g_stream.translate = jsonBody.value("is_translate", false);
+        g_stream.prompt.clear();
+        if (jsonBody.contains("initial_prompt") && jsonBody["initial_prompt"].is_string()) {
+            g_stream.prompt = jsonBody["initial_prompt"].get<std::string>();
+        }
+
+        const std::string model = jsonBody["model"].get<std::string>();
+        g_stream.ctx = whisper_init_from_file(model.c_str());
+        if (g_stream.ctx == nullptr) {
+            jsonResult["@type"] = "error";
+            jsonResult["message"] = "stream_start: failed to load model " + model;
+            return jsonToChar(jsonResult);
+        }
+
+        jsonResult["@type"] = "streamStarted";
+        return jsonToChar(jsonResult);
+    }
+
+    // pcm: 16 kHz mono float32 samples in [-1, 1].
+    char *stream_feed(const float *pcm, int32_t n_samples)
+    {
+        std::lock_guard<std::mutex> lock(g_stream.mutex);
+        json jsonResult;
+
+        if (g_stream.ctx == nullptr) {
+            jsonResult["@type"] = "error";
+            jsonResult["message"] = "stream_feed: stream not started";
+            return jsonToChar(jsonResult);
+        }
+        if (pcm != nullptr && n_samples > 0) {
+            g_stream.pcmf32.insert(g_stream.pcmf32.end(), pcm, pcm + n_samples);
+        }
+
+        if (g_stream.pcmf32.size() - g_stream.n_transcribed >= STREAM_STEP_SAMPLES) {
+            return jsonToChar(stream_run_inference());
+        }
+
+        jsonResult["@type"] = "streamPartial";
+        jsonResult["text"] = g_stream.committed + g_stream.last_text;
+        return jsonToChar(jsonResult);
+    }
+
+    char *stream_stop()
+    {
+        std::lock_guard<std::mutex> lock(g_stream.mutex);
+        json jsonResult;
+
+        if (g_stream.ctx == nullptr) {
+            jsonResult["@type"] = "error";
+            jsonResult["message"] = "stream_stop: stream not started";
+            return jsonToChar(jsonResult);
+        }
+
+        // Cover whatever audio arrived after the last run.
+        if (g_stream.pcmf32.size() > g_stream.n_transcribed &&
+            g_stream.pcmf32.size() >= (size_t)WHISPER_SAMPLE_RATE / 2) {
+            stream_run_inference();
+        }
+
+        jsonResult["@type"] = "streamFinal";
+        jsonResult["text"] = g_stream.committed + g_stream.last_text;
+
+        whisper_free(g_stream.ctx);
+        g_stream.ctx = nullptr;
+        g_stream.pcmf32.clear();
+        g_stream.pcmf32.shrink_to_fit();
+        g_stream.n_transcribed = 0;
+        g_stream.committed.clear();
+        g_stream.last_text.clear();
+
+        return jsonToChar(jsonResult);
     }
 }

--- a/macos/Classes/whisper_ggml.cpp
+++ b/macos/Classes/whisper_ggml.cpp
@@ -133,6 +133,8 @@ struct whisper_params
     bool split_on_word = false;
     // whisper_full_params.no_context: disable cross-segment text conditioning.
     bool no_context = false;
+    // whisper_full_params.suppress_non_speech_tokens: drop [BLANK_AUDIO]-style annotations.
+    bool suppress_nst = false;
 
     std::string language = "id";
     std::string prompt;
@@ -172,6 +174,10 @@ json transcribe(json jsonBody)
     if (jsonBody.contains("no_context") && jsonBody["no_context"].is_boolean())
     {
         params.no_context = jsonBody["no_context"].get<bool>();
+    }
+    if (jsonBody.contains("suppress_non_speech_tokens") && jsonBody["suppress_non_speech_tokens"].is_boolean())
+    {
+        params.suppress_nst = jsonBody["suppress_non_speech_tokens"].get<bool>();
     }
     json jsonResult;
     jsonResult["@type"] = "transcribe";
@@ -293,6 +299,7 @@ json transcribe(json jsonBody)
             wparams.initial_prompt = params.prompt.c_str();
         }
         wparams.no_context = params.no_context;
+        wparams.suppress_non_speech_tokens = params.suppress_nst;
 
         if (params.split_on_word) {
             wparams.max_len = 1;
@@ -415,6 +422,7 @@ struct whisper_stream_state
     std::string prompt;
     int n_threads = 4;
     bool translate = false;
+    bool suppress_nst = false;
     std::mutex mutex;
 };
 
@@ -437,6 +445,7 @@ static json stream_run_inference()
     wparams.language         = g_stream.language.c_str();
     wparams.n_threads        = g_stream.n_threads;
     wparams.no_context       = true;
+    wparams.suppress_non_speech_tokens = g_stream.suppress_nst;
     if (!g_stream.prompt.empty()) {
         wparams.initial_prompt = g_stream.prompt.c_str();
     }
@@ -496,6 +505,7 @@ extern "C"
         g_stream.language  = jsonBody.value("language", "en");
         g_stream.n_threads = jsonBody.value("threads", 4);
         g_stream.translate = jsonBody.value("is_translate", false);
+        g_stream.suppress_nst = jsonBody.value("suppress_non_speech_tokens", false);
         g_stream.prompt.clear();
         if (jsonBody.contains("initial_prompt") && jsonBody["initial_prompt"].is_string()) {
             g_stream.prompt = jsonBody["initial_prompt"].get<std::string>();

--- a/macos/Classes/whisper_ggml.cpp
+++ b/macos/Classes/whisper_ggml.cpp
@@ -10,6 +10,7 @@
 #include <thread>
 #include <mutex>
 #include <algorithm>
+#include <cstdlib>
 #include <vector>
 
 #include <iostream>
@@ -26,7 +27,9 @@ void print(std::string value)
 char *jsonToChar(json jsonData)
 {
     std::string result = jsonData.dump();
-    char *ch = new char[result.size() + 1];
+    // malloc, not new[]: callers across the FFI boundary free this
+    // with the C allocator (Dart's malloc.free).
+    char *ch = (char *)malloc(result.size() + 1);
     strcpy(ch, result.c_str());
     return ch;
 }
@@ -39,7 +42,7 @@ std::string charToString(char *value)
 
 char *stringToChar(std::string value)
 {
-    char *ch = new char[value.size() + 1];
+    char *ch = (char *)malloc(value.size() + 1);
     strcpy(ch, value.c_str());
     return ch;
 }
@@ -424,6 +427,9 @@ struct whisper_stream_state
     size_t n_transcribed = 0;    // window samples covered by the last run
     size_t n_voiced = 0;         // end of the last chunk with speech energy
     float noise_floor = 0.005f;  // adaptive ambient RMS estimate
+    float gate_rms_min = 0.0015f;   // absolute minimum speech RMS
+    float gate_ratio = 2.5f;        // voiced thold = ratio * noise_floor
+    float gate_floor_cap = 0.01f;   // noise_floor cap (loud rooms)
     std::string committed;       // text of windows already committed
     std::string last_text;       // text of the current window's last run
     std::string language = "en";
@@ -438,8 +444,6 @@ static whisper_stream_state g_stream;
 
 static const size_t STREAM_STEP_SAMPLES   = (size_t)(1.5 * WHISPER_SAMPLE_RATE);
 static const size_t STREAM_COMMIT_SAMPLES = (size_t)(25.0 * WHISPER_SAMPLE_RATE);
-// Absolute minimum RMS for speech, regardless of the adaptive floor.
-static const float  STREAM_VOICE_RMS      = 0.0015f;
 // Decode this much audio past the last voiced sample (trailing consonants).
 static const size_t STREAM_VOICE_PAD      = (size_t)(0.2 * WHISPER_SAMPLE_RATE);
 
@@ -466,7 +470,7 @@ static json stream_run_inference()
     // whisper hallucinate (repeats or invented phrases).
     const size_t n_decode =
         std::min(g_stream.pcmf32.size(), g_stream.n_voiced + STREAM_VOICE_PAD);
-    if (n_decode == 0) {
+    if (n_decode < (size_t)WHISPER_SAMPLE_RATE / 2) {
         result["text"] = g_stream.committed + g_stream.last_text;
         return result;
     }
@@ -527,16 +531,28 @@ extern "C"
         g_stream.committed.clear();
         g_stream.last_text.clear();
 
-        g_stream.language  = jsonBody.value("language", "en");
-        g_stream.n_threads = jsonBody.value("threads", 4);
-        g_stream.translate = jsonBody.value("is_translate", false);
-        g_stream.suppress_nst = jsonBody.value("suppress_non_speech_tokens", false);
-        g_stream.prompt.clear();
-        if (jsonBody.contains("initial_prompt") && jsonBody["initial_prompt"].is_string()) {
-            g_stream.prompt = jsonBody["initial_prompt"].get<std::string>();
+        std::string model;
+        try {
+            g_stream.language  = jsonBody.value("language", "en");
+            g_stream.n_threads = jsonBody.value("threads", 4);
+            g_stream.translate = jsonBody.value("is_translate", false);
+            g_stream.suppress_nst = jsonBody.value("suppress_non_speech_tokens", false);
+            g_stream.gate_rms_min   = (float)jsonBody.value("gate_rms_min", 0.0015);
+            g_stream.gate_ratio     = (float)jsonBody.value("gate_voice_ratio", 2.5);
+            g_stream.gate_floor_cap = (float)jsonBody.value("gate_floor_cap", 0.01);
+            g_stream.prompt.clear();
+            if (jsonBody.contains("initial_prompt") && jsonBody["initial_prompt"].is_string()) {
+                g_stream.prompt = jsonBody["initial_prompt"].get<std::string>();
+            }
+            model = jsonBody["model"].get<std::string>();
+        } catch (const json::exception &e) {
+            // A C++ exception escaping extern "C" into FFI would be
+            // std::terminate; convert type errors to an error response.
+            jsonResult["@type"] = "error";
+            jsonResult["message"] =
+                std::string("stream_start: bad request: ") + e.what();
+            return jsonToChar(jsonResult);
         }
-
-        const std::string model = jsonBody["model"].get<std::string>();
         g_stream.ctx = whisper_init_from_file(model.c_str());
         if (g_stream.ctx == nullptr) {
             jsonResult["@type"] = "error";
@@ -575,9 +591,11 @@ extern "C"
             } else {
                 g_stream.noise_floor += 0.0005f * (rms - g_stream.noise_floor);
             }
-            g_stream.noise_floor = std::min(g_stream.noise_floor, 0.01f);
-            const float voice_thold =
-                std::max(2.5f * g_stream.noise_floor, STREAM_VOICE_RMS);
+            g_stream.noise_floor =
+                std::min(g_stream.noise_floor, g_stream.gate_floor_cap);
+            const float voice_thold = std::max(
+                g_stream.gate_ratio * g_stream.noise_floor,
+                g_stream.gate_rms_min);
             if (rms >= voice_thold) {
                 g_stream.n_voiced = g_stream.pcmf32.size();
             }

--- a/test/transcribe_request_dto_test.dart
+++ b/test/transcribe_request_dto_test.dart
@@ -38,6 +38,26 @@ void main() {
       expect(body['no_context'], isTrue);
     });
 
+    test('suppressNonSpeechTokens defaults to false and forwards true', () {
+      final defaultDto = TranscribeRequestDto.fromTranscribeRequest(
+        request(),
+        '/tmp/model.bin',
+      );
+      final defaultBody =
+          json.decode(defaultDto.toRequestString()) as Map<String, dynamic>;
+      expect(defaultBody['suppress_non_speech_tokens'], isFalse);
+
+      final dto = TranscribeRequestDto.fromTranscribeRequest(
+        const TranscribeRequest(
+          audio: '/tmp/audio.wav',
+          suppressNonSpeechTokens: true,
+        ),
+        '/tmp/model.bin',
+      );
+      final body = json.decode(dto.toRequestString()) as Map<String, dynamic>;
+      expect(body['suppress_non_speech_tokens'], isTrue);
+    });
+
     test('fromJson defaults no_context to false when key is absent', () {
       final dto = TranscribeRequestDto.fromJson(const {
         'audio': '/tmp/audio.wav',


### PR DESCRIPTION
## Summary

Adds live transcription: partial transcripts appear **while the user speaks** instead of only after recording stops.

### Native (Android / iOS / macOS)
- New streaming API alongside the existing `request()`: `stream_start` / `stream_feed` / `stream_stop`. A session loads the model **once** and keeps one `whisper_context` alive (the one-shot path reloads the model from disk on every call, which made live use impossible).
- `stream_feed` accumulates 16 kHz float PCM and re-decodes the current window (with `no_context`) once ~1.5 s of new **voiced** audio arrives; past ~25 s the window's text is committed and the buffer restarts, keeping memory and per-inference cost bounded.
- **Adaptive energy gate**: an ambient-RMS noise floor (falls fast, rises slowly, capped) marks chunks as voiced; silence — digital or room tone — never reaches the decoder. Without this, whisper hallucinates over trailing silence (`[BLANK_AUDIO]`, repeated sentences, invented phrases).

### Dart
- `WhisperController.transcribeLive({model, pcm16Stream, lang, initialPrompt, suppressNonSpeechTokens})` → `WhisperLiveSession` with a `partials` stream (each event is the full refined text) and `stop()` → final transcript.
- Takes a plain `Stream<Uint8List>` of 16 kHz mono PCM16, so the plugin stays recorder-agnostic. All FFI runs on a dedicated worker isolate; inference never blocks the UI.
- New `suppressNonSpeechTokens` option on `TranscribeRequest`, `transcribe`, and `transcribeLive`, mapped to `whisper_full_params.suppress_non_speech_tokens` on all three platforms (both one-shot and streaming). Default `false`.

### Example app
- Redesigned UI: **Live mic** and **Record** buttons (active one becomes a red Stop), a **JFK sample** button with a play icon, transcript card with empty state and selectable text, and a status line.
- Adds the missing `com.apple.security.device.audio-input` entitlement (mic capture on macOS was broken without it).
- Fixes a crash writing to a not-yet-created sandbox temp directory.

### Tooling
- `build.yaml` restricting codegen sources — `build_runner` otherwise crawls `example/ios/.symlinks` / `.fvm` symlink loops (~49k inputs) and effectively hangs.

## Testing
- Unit tests for the DTO wire format (4 passing), `flutter analyze` clean.
- macOS release-mode verification with a **real microphone**: jfk.wav played through speakers transcribed correctly with progressively refining partials; trailing room silence no longer produces `[BLANK_AUDIO]` or repetition.
- Synthetic stress test (jfk + 8 s digital silence, suppression on and off): clean transcripts in all combinations.
- Android debug APK compiles (NDK); iOS shares the macOS-compiled source.

## Known limitations (documented in code)
- One global native stream session (no concurrent streams).
- Real non-speech transients (knocks, clicks) still decode — as bracketed annotations, or as plausible-looking words when suppression is on (why the example keeps it off). Proper speech/sound separation needs a VAD model or a whisper.cpp upgrade with working `no_speech_prob`.
- A word straddling the ~25 s commit boundary may clip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)