### PR TITLE
feat: Silero VAD passthrough for transcribe (vad_model, vad_speech_pad_ms)

### DIFF
--- a/android/src/whisper/main.cpp
+++ b/android/src/whisper/main.cpp
@@ -79,6 +79,13 @@ struct whisper_params
     // multi-second load (issue #26). Off = load-per-request, as always.
     bool keep_model_loaded = false;
 
+    // Silero VAD (whisper.cpp built-in): trims non-speech before decoding,
+    // which stops whisper hallucinating or looping over leading/trailing
+    // silence in push-to-talk recordings. Empty = VAD off (default).
+    std::string vad_model;
+    // speech_pad_ms override; negative keeps whisper.cpp's default.
+    int32_t vad_speech_pad_ms = -1;
+
     std::string language = "auto";
     std::string prompt;
     std::string model = "models/ggml-tiny.bin";
@@ -169,6 +176,14 @@ json transcribe(json jsonBody) noexcept
     if (jsonBody.contains("keep_model_loaded") && jsonBody["keep_model_loaded"].is_boolean())
     {
         params.keep_model_loaded = jsonBody["keep_model_loaded"].get<bool>();
+    }
+    if (jsonBody.contains("vad_model") && jsonBody["vad_model"].is_string())
+    {
+        params.vad_model = jsonBody["vad_model"].get<std::string>();
+    }
+    if (jsonBody.contains("vad_speech_pad_ms") && jsonBody["vad_speech_pad_ms"].is_number_integer())
+    {
+        params.vad_speech_pad_ms = jsonBody["vad_speech_pad_ms"].get<int32_t>();
     }
     json jsonResult;
     jsonResult["@type"] = "transcribe";
@@ -336,6 +351,17 @@ json transcribe(json jsonBody) noexcept
         // unaffected — whisper re-applies it after the clear.
         wparams.no_context = params.no_context || reused_ctx;
         wparams.suppress_nst = params.suppress_nst;
+
+        // params.vad_model outlives whisper_full(), so the pointer stays
+        // valid for the whole decode.
+        if (!params.vad_model.empty()) {
+            wparams.vad = true;
+            wparams.vad_model_path = params.vad_model.c_str();
+            wparams.vad_params = whisper_vad_default_params();
+            if (params.vad_speech_pad_ms >= 0) {
+                wparams.vad_params.speech_pad_ms = params.vad_speech_pad_ms;
+            }
+        }
 
         if (params.split_on_word) {
             wparams.max_len = 1;

--- a/ios/Classes/whisper_flutter_plus.cpp
+++ b/ios/Classes/whisper_flutter_plus.cpp
@@ -152,6 +152,13 @@ struct whisper_params
     // multi-second load (issue #26). Off = load-per-request, as always.
     bool keep_model_loaded = false;
 
+    // Silero VAD (whisper.cpp built-in): trims non-speech before decoding,
+    // which stops whisper hallucinating or looping over leading/trailing
+    // silence in push-to-talk recordings. Empty = VAD off (default).
+    std::string vad_model;
+    // speech_pad_ms override; negative keeps whisper.cpp's default.
+    int32_t vad_speech_pad_ms = -1;
+
     std::string language = "id";
     std::string prompt;
     std::string model = "models/ggml-model-whisper-small.bin";
@@ -242,6 +249,14 @@ json transcribe(json jsonBody)
     if (jsonBody.contains("keep_model_loaded") && jsonBody["keep_model_loaded"].is_boolean())
     {
         params.keep_model_loaded = jsonBody["keep_model_loaded"].get<bool>();
+    }
+    if (jsonBody.contains("vad_model") && jsonBody["vad_model"].is_string())
+    {
+        params.vad_model = jsonBody["vad_model"].get<std::string>();
+    }
+    if (jsonBody.contains("vad_speech_pad_ms") && jsonBody["vad_speech_pad_ms"].is_number_integer())
+    {
+        params.vad_speech_pad_ms = jsonBody["vad_speech_pad_ms"].get<int32_t>();
     }
     json jsonResult;
     jsonResult["@type"] = "transcribe";
@@ -424,6 +439,17 @@ json transcribe(json jsonBody)
         // unaffected — whisper re-applies it after the clear.
         wparams.no_context = params.no_context || reused_ctx;
         wparams.suppress_nst = params.suppress_nst;
+
+        // params.vad_model outlives whisper_full(), so the pointer stays
+        // valid for the whole decode.
+        if (!params.vad_model.empty()) {
+            wparams.vad = true;
+            wparams.vad_model_path = params.vad_model.c_str();
+            wparams.vad_params = whisper_vad_default_params();
+            if (params.vad_speech_pad_ms >= 0) {
+                wparams.vad_params.speech_pad_ms = params.vad_speech_pad_ms;
+            }
+        }
 
         if (params.split_on_word) {
             wparams.max_len = 1;

--- a/lib/src/models/requests/transcribe_request.dart
+++ b/lib/src/models/requests/transcribe_request.dart
@@ -83,6 +83,27 @@ abstract class TranscribeRequest with _$TranscribeRequest {
     /// Default `false` preserves the load-per-request behaviour of every
     /// previous version.
     @Default(false) bool keepModelLoaded,
+
+    /// Path to a Silero VAD model (e.g. `ggml-silero-v5.1.2.bin`),
+    /// enabling whisper.cpp's built-in voice-activity detection for this
+    /// request.
+    ///
+    /// VAD trims non-speech from the audio before decoding — the standard
+    /// defence against whisper hallucinating or looping over the leading
+    /// and trailing silence of push-to-talk recordings. The VAD models are
+    /// small (~1 MB) and add little latency relative to the decode they
+    /// shorten.
+    ///
+    /// Null (default) leaves VAD off, matching the behaviour of every
+    /// previous version.
+    @Default(null) String? vadModelPath,
+
+    /// Padding in milliseconds kept around each detected speech segment
+    /// when [vadModelPath] is set, so clipped first and last words stay
+    /// intact. Null keeps whisper.cpp's default. Values around 100 ms work
+    /// well for push-to-talk; much larger values can garble segment
+    /// boundaries. Ignored when [vadModelPath] is null.
+    @Default(null) int? vadSpeechPadMs,
   }) = _TranscribeRequest;
   const TranscribeRequest._();
 }

--- a/lib/src/models/requests/transcribe_request.dart
+++ b/lib/src/models/requests/transcribe_request.dart
@@ -100,9 +100,10 @@ abstract class TranscribeRequest with _$TranscribeRequest {
 
     /// Padding in milliseconds kept around each detected speech segment
     /// when [vadModelPath] is set, so clipped first and last words stay
-    /// intact. Null keeps whisper.cpp's default. Values around 100 ms work
-    /// well for push-to-talk; much larger values can garble segment
-    /// boundaries. Ignored when [vadModelPath] is null.
+    /// intact. Null keeps whisper.cpp's default, and negative values are
+    /// treated the same as null. Values around 100 ms work well for
+    /// push-to-talk; much larger values can garble segment boundaries.
+    /// Ignored when [vadModelPath] is null.
     @Default(null) int? vadSpeechPadMs,
   }) = _TranscribeRequest;
   const TranscribeRequest._();

--- a/lib/src/models/requests/transcribe_request.freezed.dart
+++ b/lib/src/models/requests/transcribe_request.freezed.dart
@@ -83,9 +83,10 @@ mixin _$TranscribeRequest {
 /// previous version.
  String? get vadModelPath;/// Padding in milliseconds kept around each detected speech segment
 /// when [vadModelPath] is set, so clipped first and last words stay
-/// intact. Null keeps whisper.cpp's default. Values around 100 ms work
-/// well for push-to-talk; much larger values can garble segment
-/// boundaries. Ignored when [vadModelPath] is null.
+/// intact. Null keeps whisper.cpp's default, and negative values are
+/// treated the same as null. Values around 100 ms work well for
+/// push-to-talk; much larger values can garble segment boundaries.
+/// Ignored when [vadModelPath] is null.
  int? get vadSpeechPadMs;
 /// Create a copy of TranscribeRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -388,9 +389,10 @@ class _TranscribeRequest extends TranscribeRequest {
 @override@JsonKey() final  String? vadModelPath;
 /// Padding in milliseconds kept around each detected speech segment
 /// when [vadModelPath] is set, so clipped first and last words stay
-/// intact. Null keeps whisper.cpp's default. Values around 100 ms work
-/// well for push-to-talk; much larger values can garble segment
-/// boundaries. Ignored when [vadModelPath] is null.
+/// intact. Null keeps whisper.cpp's default, and negative values are
+/// treated the same as null. Values around 100 ms work well for
+/// push-to-talk; much larger values can garble segment boundaries.
+/// Ignored when [vadModelPath] is null.
 @override@JsonKey() final  int? vadSpeechPadMs;
 
 /// Create a copy of TranscribeRequest

--- a/lib/src/models/requests/transcribe_request.freezed.dart
+++ b/lib/src/models/requests/transcribe_request.freezed.dart
@@ -69,7 +69,24 @@ mixin _$TranscribeRequest {
 ///
 /// Default `false` preserves the load-per-request behaviour of every
 /// previous version.
- bool get keepModelLoaded;
+ bool get keepModelLoaded;/// Path to a Silero VAD model (e.g. `ggml-silero-v5.1.2.bin`),
+/// enabling whisper.cpp's built-in voice-activity detection for this
+/// request.
+///
+/// VAD trims non-speech from the audio before decoding — the standard
+/// defence against whisper hallucinating or looping over the leading
+/// and trailing silence of push-to-talk recordings. The VAD models are
+/// small (~1 MB) and add little latency relative to the decode they
+/// shorten.
+///
+/// Null (default) leaves VAD off, matching the behaviour of every
+/// previous version.
+ String? get vadModelPath;/// Padding in milliseconds kept around each detected speech segment
+/// when [vadModelPath] is set, so clipped first and last words stay
+/// intact. Null keeps whisper.cpp's default. Values around 100 ms work
+/// well for push-to-talk; much larger values can garble segment
+/// boundaries. Ignored when [vadModelPath] is null.
+ int? get vadSpeechPadMs;
 /// Create a copy of TranscribeRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -80,16 +97,16 @@ $TranscribeRequestCopyWith<TranscribeRequest> get copyWith => _$TranscribeReques
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is TranscribeRequest&&(identical(other.audio, audio) || other.audio == audio)&&(identical(other.isTranslate, isTranslate) || other.isTranslate == isTranslate)&&(identical(other.threads, threads) || other.threads == threads)&&(identical(other.isVerbose, isVerbose) || other.isVerbose == isVerbose)&&(identical(other.language, language) || other.language == language)&&(identical(other.isSpecialTokens, isSpecialTokens) || other.isSpecialTokens == isSpecialTokens)&&(identical(other.isNoTimestamps, isNoTimestamps) || other.isNoTimestamps == isNoTimestamps)&&(identical(other.isRealtime, isRealtime) || other.isRealtime == isRealtime)&&(identical(other.nProcessors, nProcessors) || other.nProcessors == nProcessors)&&(identical(other.splitOnWord, splitOnWord) || other.splitOnWord == splitOnWord)&&(identical(other.noFallback, noFallback) || other.noFallback == noFallback)&&(identical(other.diarize, diarize) || other.diarize == diarize)&&(identical(other.speedUp, speedUp) || other.speedUp == speedUp)&&(identical(other.realtimeStream, realtimeStream) || other.realtimeStream == realtimeStream)&&(identical(other.initialPrompt, initialPrompt) || other.initialPrompt == initialPrompt)&&(identical(other.noContext, noContext) || other.noContext == noContext)&&(identical(other.suppressNonSpeechTokens, suppressNonSpeechTokens) || other.suppressNonSpeechTokens == suppressNonSpeechTokens)&&(identical(other.keepModelLoaded, keepModelLoaded) || other.keepModelLoaded == keepModelLoaded));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TranscribeRequest&&(identical(other.audio, audio) || other.audio == audio)&&(identical(other.isTranslate, isTranslate) || other.isTranslate == isTranslate)&&(identical(other.threads, threads) || other.threads == threads)&&(identical(other.isVerbose, isVerbose) || other.isVerbose == isVerbose)&&(identical(other.language, language) || other.language == language)&&(identical(other.isSpecialTokens, isSpecialTokens) || other.isSpecialTokens == isSpecialTokens)&&(identical(other.isNoTimestamps, isNoTimestamps) || other.isNoTimestamps == isNoTimestamps)&&(identical(other.isRealtime, isRealtime) || other.isRealtime == isRealtime)&&(identical(other.nProcessors, nProcessors) || other.nProcessors == nProcessors)&&(identical(other.splitOnWord, splitOnWord) || other.splitOnWord == splitOnWord)&&(identical(other.noFallback, noFallback) || other.noFallback == noFallback)&&(identical(other.diarize, diarize) || other.diarize == diarize)&&(identical(other.speedUp, speedUp) || other.speedUp == speedUp)&&(identical(other.realtimeStream, realtimeStream) || other.realtimeStream == realtimeStream)&&(identical(other.initialPrompt, initialPrompt) || other.initialPrompt == initialPrompt)&&(identical(other.noContext, noContext) || other.noContext == noContext)&&(identical(other.suppressNonSpeechTokens, suppressNonSpeechTokens) || other.suppressNonSpeechTokens == suppressNonSpeechTokens)&&(identical(other.keepModelLoaded, keepModelLoaded) || other.keepModelLoaded == keepModelLoaded)&&(identical(other.vadModelPath, vadModelPath) || other.vadModelPath == vadModelPath)&&(identical(other.vadSpeechPadMs, vadSpeechPadMs) || other.vadSpeechPadMs == vadSpeechPadMs));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,audio,isTranslate,threads,isVerbose,language,isSpecialTokens,isNoTimestamps,isRealtime,nProcessors,splitOnWord,noFallback,diarize,speedUp,realtimeStream,initialPrompt,noContext,suppressNonSpeechTokens,keepModelLoaded);
+int get hashCode => Object.hashAll([runtimeType,audio,isTranslate,threads,isVerbose,language,isSpecialTokens,isNoTimestamps,isRealtime,nProcessors,splitOnWord,noFallback,diarize,speedUp,realtimeStream,initialPrompt,noContext,suppressNonSpeechTokens,keepModelLoaded,vadModelPath,vadSpeechPadMs]);
 
 @override
 String toString() {
-  return 'TranscribeRequest(audio: $audio, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, isRealtime: $isRealtime, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, diarize: $diarize, speedUp: $speedUp, realtimeStream: $realtimeStream, initialPrompt: $initialPrompt, noContext: $noContext, suppressNonSpeechTokens: $suppressNonSpeechTokens, keepModelLoaded: $keepModelLoaded)';
+  return 'TranscribeRequest(audio: $audio, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, isRealtime: $isRealtime, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, diarize: $diarize, speedUp: $speedUp, realtimeStream: $realtimeStream, initialPrompt: $initialPrompt, noContext: $noContext, suppressNonSpeechTokens: $suppressNonSpeechTokens, keepModelLoaded: $keepModelLoaded, vadModelPath: $vadModelPath, vadSpeechPadMs: $vadSpeechPadMs)';
 }
 
 
@@ -100,7 +117,7 @@ abstract mixin class $TranscribeRequestCopyWith<$Res>  {
   factory $TranscribeRequestCopyWith(TranscribeRequest value, $Res Function(TranscribeRequest) _then) = _$TranscribeRequestCopyWithImpl;
 @useResult
 $Res call({
- String audio, bool isTranslate, int threads, bool isVerbose, String language, bool isSpecialTokens, bool isNoTimestamps, bool isRealtime, int nProcessors, bool splitOnWord, bool noFallback, bool diarize, bool speedUp, Stream<String>? realtimeStream, String? initialPrompt, bool noContext, bool suppressNonSpeechTokens, bool keepModelLoaded
+ String audio, bool isTranslate, int threads, bool isVerbose, String language, bool isSpecialTokens, bool isNoTimestamps, bool isRealtime, int nProcessors, bool splitOnWord, bool noFallback, bool diarize, bool speedUp, Stream<String>? realtimeStream, String? initialPrompt, bool noContext, bool suppressNonSpeechTokens, bool keepModelLoaded, String? vadModelPath, int? vadSpeechPadMs
 });
 
 
@@ -117,7 +134,7 @@ class _$TranscribeRequestCopyWithImpl<$Res>
 
 /// Create a copy of TranscribeRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? audio = null,Object? isTranslate = null,Object? threads = null,Object? isVerbose = null,Object? language = null,Object? isSpecialTokens = null,Object? isNoTimestamps = null,Object? isRealtime = null,Object? nProcessors = null,Object? splitOnWord = null,Object? noFallback = null,Object? diarize = null,Object? speedUp = null,Object? realtimeStream = freezed,Object? initialPrompt = freezed,Object? noContext = null,Object? suppressNonSpeechTokens = null,Object? keepModelLoaded = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? audio = null,Object? isTranslate = null,Object? threads = null,Object? isVerbose = null,Object? language = null,Object? isSpecialTokens = null,Object? isNoTimestamps = null,Object? isRealtime = null,Object? nProcessors = null,Object? splitOnWord = null,Object? noFallback = null,Object? diarize = null,Object? speedUp = null,Object? realtimeStream = freezed,Object? initialPrompt = freezed,Object? noContext = null,Object? suppressNonSpeechTokens = null,Object? keepModelLoaded = null,Object? vadModelPath = freezed,Object? vadSpeechPadMs = freezed,}) {
   return _then(_self.copyWith(
 audio: null == audio ? _self.audio : audio // ignore: cast_nullable_to_non_nullable
 as String,isTranslate: null == isTranslate ? _self.isTranslate : isTranslate // ignore: cast_nullable_to_non_nullable
@@ -137,7 +154,9 @@ as Stream<String>?,initialPrompt: freezed == initialPrompt ? _self.initialPrompt
 as String?,noContext: null == noContext ? _self.noContext : noContext // ignore: cast_nullable_to_non_nullable
 as bool,suppressNonSpeechTokens: null == suppressNonSpeechTokens ? _self.suppressNonSpeechTokens : suppressNonSpeechTokens // ignore: cast_nullable_to_non_nullable
 as bool,keepModelLoaded: null == keepModelLoaded ? _self.keepModelLoaded : keepModelLoaded // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,vadModelPath: freezed == vadModelPath ? _self.vadModelPath : vadModelPath // ignore: cast_nullable_to_non_nullable
+as String?,vadSpeechPadMs: freezed == vadSpeechPadMs ? _self.vadSpeechPadMs : vadSpeechPadMs // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 
@@ -222,10 +241,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String audio,  bool isTranslate,  int threads,  bool isVerbose,  String language,  bool isSpecialTokens,  bool isNoTimestamps,  bool isRealtime,  int nProcessors,  bool splitOnWord,  bool noFallback,  bool diarize,  bool speedUp,  Stream<String>? realtimeStream,  String? initialPrompt,  bool noContext,  bool suppressNonSpeechTokens,  bool keepModelLoaded)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String audio,  bool isTranslate,  int threads,  bool isVerbose,  String language,  bool isSpecialTokens,  bool isNoTimestamps,  bool isRealtime,  int nProcessors,  bool splitOnWord,  bool noFallback,  bool diarize,  bool speedUp,  Stream<String>? realtimeStream,  String? initialPrompt,  bool noContext,  bool suppressNonSpeechTokens,  bool keepModelLoaded,  String? vadModelPath,  int? vadSpeechPadMs)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _TranscribeRequest() when $default != null:
-return $default(_that.audio,_that.isTranslate,_that.threads,_that.isVerbose,_that.language,_that.isSpecialTokens,_that.isNoTimestamps,_that.isRealtime,_that.nProcessors,_that.splitOnWord,_that.noFallback,_that.diarize,_that.speedUp,_that.realtimeStream,_that.initialPrompt,_that.noContext,_that.suppressNonSpeechTokens,_that.keepModelLoaded);case _:
+return $default(_that.audio,_that.isTranslate,_that.threads,_that.isVerbose,_that.language,_that.isSpecialTokens,_that.isNoTimestamps,_that.isRealtime,_that.nProcessors,_that.splitOnWord,_that.noFallback,_that.diarize,_that.speedUp,_that.realtimeStream,_that.initialPrompt,_that.noContext,_that.suppressNonSpeechTokens,_that.keepModelLoaded,_that.vadModelPath,_that.vadSpeechPadMs);case _:
   return orElse();
 
 }
@@ -243,10 +262,10 @@ return $default(_that.audio,_that.isTranslate,_that.threads,_that.isVerbose,_tha
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String audio,  bool isTranslate,  int threads,  bool isVerbose,  String language,  bool isSpecialTokens,  bool isNoTimestamps,  bool isRealtime,  int nProcessors,  bool splitOnWord,  bool noFallback,  bool diarize,  bool speedUp,  Stream<String>? realtimeStream,  String? initialPrompt,  bool noContext,  bool suppressNonSpeechTokens,  bool keepModelLoaded)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String audio,  bool isTranslate,  int threads,  bool isVerbose,  String language,  bool isSpecialTokens,  bool isNoTimestamps,  bool isRealtime,  int nProcessors,  bool splitOnWord,  bool noFallback,  bool diarize,  bool speedUp,  Stream<String>? realtimeStream,  String? initialPrompt,  bool noContext,  bool suppressNonSpeechTokens,  bool keepModelLoaded,  String? vadModelPath,  int? vadSpeechPadMs)  $default,) {final _that = this;
 switch (_that) {
 case _TranscribeRequest():
-return $default(_that.audio,_that.isTranslate,_that.threads,_that.isVerbose,_that.language,_that.isSpecialTokens,_that.isNoTimestamps,_that.isRealtime,_that.nProcessors,_that.splitOnWord,_that.noFallback,_that.diarize,_that.speedUp,_that.realtimeStream,_that.initialPrompt,_that.noContext,_that.suppressNonSpeechTokens,_that.keepModelLoaded);case _:
+return $default(_that.audio,_that.isTranslate,_that.threads,_that.isVerbose,_that.language,_that.isSpecialTokens,_that.isNoTimestamps,_that.isRealtime,_that.nProcessors,_that.splitOnWord,_that.noFallback,_that.diarize,_that.speedUp,_that.realtimeStream,_that.initialPrompt,_that.noContext,_that.suppressNonSpeechTokens,_that.keepModelLoaded,_that.vadModelPath,_that.vadSpeechPadMs);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -263,10 +282,10 @@ return $default(_that.audio,_that.isTranslate,_that.threads,_that.isVerbose,_tha
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String audio,  bool isTranslate,  int threads,  bool isVerbose,  String language,  bool isSpecialTokens,  bool isNoTimestamps,  bool isRealtime,  int nProcessors,  bool splitOnWord,  bool noFallback,  bool diarize,  bool speedUp,  Stream<String>? realtimeStream,  String? initialPrompt,  bool noContext,  bool suppressNonSpeechTokens,  bool keepModelLoaded)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String audio,  bool isTranslate,  int threads,  bool isVerbose,  String language,  bool isSpecialTokens,  bool isNoTimestamps,  bool isRealtime,  int nProcessors,  bool splitOnWord,  bool noFallback,  bool diarize,  bool speedUp,  Stream<String>? realtimeStream,  String? initialPrompt,  bool noContext,  bool suppressNonSpeechTokens,  bool keepModelLoaded,  String? vadModelPath,  int? vadSpeechPadMs)?  $default,) {final _that = this;
 switch (_that) {
 case _TranscribeRequest() when $default != null:
-return $default(_that.audio,_that.isTranslate,_that.threads,_that.isVerbose,_that.language,_that.isSpecialTokens,_that.isNoTimestamps,_that.isRealtime,_that.nProcessors,_that.splitOnWord,_that.noFallback,_that.diarize,_that.speedUp,_that.realtimeStream,_that.initialPrompt,_that.noContext,_that.suppressNonSpeechTokens,_that.keepModelLoaded);case _:
+return $default(_that.audio,_that.isTranslate,_that.threads,_that.isVerbose,_that.language,_that.isSpecialTokens,_that.isNoTimestamps,_that.isRealtime,_that.nProcessors,_that.splitOnWord,_that.noFallback,_that.diarize,_that.speedUp,_that.realtimeStream,_that.initialPrompt,_that.noContext,_that.suppressNonSpeechTokens,_that.keepModelLoaded,_that.vadModelPath,_that.vadSpeechPadMs);case _:
   return null;
 
 }
@@ -278,7 +297,7 @@ return $default(_that.audio,_that.isTranslate,_that.threads,_that.isVerbose,_tha
 
 
 class _TranscribeRequest extends TranscribeRequest {
-  const _TranscribeRequest({required this.audio, this.isTranslate = false, this.threads = 6, this.isVerbose = false, this.language = 'en', this.isSpecialTokens = false, this.isNoTimestamps = false, this.isRealtime = false, this.nProcessors = 1, this.splitOnWord = false, this.noFallback = false, this.diarize = false, this.speedUp = false, this.realtimeStream = null, this.initialPrompt = null, this.noContext = false, this.suppressNonSpeechTokens = false, this.keepModelLoaded = false}): super._();
+  const _TranscribeRequest({required this.audio, this.isTranslate = false, this.threads = 6, this.isVerbose = false, this.language = 'en', this.isSpecialTokens = false, this.isNoTimestamps = false, this.isRealtime = false, this.nProcessors = 1, this.splitOnWord = false, this.noFallback = false, this.diarize = false, this.speedUp = false, this.realtimeStream = null, this.initialPrompt = null, this.noContext = false, this.suppressNonSpeechTokens = false, this.keepModelLoaded = false, this.vadModelPath = null, this.vadSpeechPadMs = null}): super._();
   
 
 @override final  String audio;
@@ -354,6 +373,25 @@ class _TranscribeRequest extends TranscribeRequest {
 /// Default `false` preserves the load-per-request behaviour of every
 /// previous version.
 @override@JsonKey() final  bool keepModelLoaded;
+/// Path to a Silero VAD model (e.g. `ggml-silero-v5.1.2.bin`),
+/// enabling whisper.cpp's built-in voice-activity detection for this
+/// request.
+///
+/// VAD trims non-speech from the audio before decoding — the standard
+/// defence against whisper hallucinating or looping over the leading
+/// and trailing silence of push-to-talk recordings. The VAD models are
+/// small (~1 MB) and add little latency relative to the decode they
+/// shorten.
+///
+/// Null (default) leaves VAD off, matching the behaviour of every
+/// previous version.
+@override@JsonKey() final  String? vadModelPath;
+/// Padding in milliseconds kept around each detected speech segment
+/// when [vadModelPath] is set, so clipped first and last words stay
+/// intact. Null keeps whisper.cpp's default. Values around 100 ms work
+/// well for push-to-talk; much larger values can garble segment
+/// boundaries. Ignored when [vadModelPath] is null.
+@override@JsonKey() final  int? vadSpeechPadMs;
 
 /// Create a copy of TranscribeRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -365,16 +403,16 @@ _$TranscribeRequestCopyWith<_TranscribeRequest> get copyWith => __$TranscribeReq
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TranscribeRequest&&(identical(other.audio, audio) || other.audio == audio)&&(identical(other.isTranslate, isTranslate) || other.isTranslate == isTranslate)&&(identical(other.threads, threads) || other.threads == threads)&&(identical(other.isVerbose, isVerbose) || other.isVerbose == isVerbose)&&(identical(other.language, language) || other.language == language)&&(identical(other.isSpecialTokens, isSpecialTokens) || other.isSpecialTokens == isSpecialTokens)&&(identical(other.isNoTimestamps, isNoTimestamps) || other.isNoTimestamps == isNoTimestamps)&&(identical(other.isRealtime, isRealtime) || other.isRealtime == isRealtime)&&(identical(other.nProcessors, nProcessors) || other.nProcessors == nProcessors)&&(identical(other.splitOnWord, splitOnWord) || other.splitOnWord == splitOnWord)&&(identical(other.noFallback, noFallback) || other.noFallback == noFallback)&&(identical(other.diarize, diarize) || other.diarize == diarize)&&(identical(other.speedUp, speedUp) || other.speedUp == speedUp)&&(identical(other.realtimeStream, realtimeStream) || other.realtimeStream == realtimeStream)&&(identical(other.initialPrompt, initialPrompt) || other.initialPrompt == initialPrompt)&&(identical(other.noContext, noContext) || other.noContext == noContext)&&(identical(other.suppressNonSpeechTokens, suppressNonSpeechTokens) || other.suppressNonSpeechTokens == suppressNonSpeechTokens)&&(identical(other.keepModelLoaded, keepModelLoaded) || other.keepModelLoaded == keepModelLoaded));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TranscribeRequest&&(identical(other.audio, audio) || other.audio == audio)&&(identical(other.isTranslate, isTranslate) || other.isTranslate == isTranslate)&&(identical(other.threads, threads) || other.threads == threads)&&(identical(other.isVerbose, isVerbose) || other.isVerbose == isVerbose)&&(identical(other.language, language) || other.language == language)&&(identical(other.isSpecialTokens, isSpecialTokens) || other.isSpecialTokens == isSpecialTokens)&&(identical(other.isNoTimestamps, isNoTimestamps) || other.isNoTimestamps == isNoTimestamps)&&(identical(other.isRealtime, isRealtime) || other.isRealtime == isRealtime)&&(identical(other.nProcessors, nProcessors) || other.nProcessors == nProcessors)&&(identical(other.splitOnWord, splitOnWord) || other.splitOnWord == splitOnWord)&&(identical(other.noFallback, noFallback) || other.noFallback == noFallback)&&(identical(other.diarize, diarize) || other.diarize == diarize)&&(identical(other.speedUp, speedUp) || other.speedUp == speedUp)&&(identical(other.realtimeStream, realtimeStream) || other.realtimeStream == realtimeStream)&&(identical(other.initialPrompt, initialPrompt) || other.initialPrompt == initialPrompt)&&(identical(other.noContext, noContext) || other.noContext == noContext)&&(identical(other.suppressNonSpeechTokens, suppressNonSpeechTokens) || other.suppressNonSpeechTokens == suppressNonSpeechTokens)&&(identical(other.keepModelLoaded, keepModelLoaded) || other.keepModelLoaded == keepModelLoaded)&&(identical(other.vadModelPath, vadModelPath) || other.vadModelPath == vadModelPath)&&(identical(other.vadSpeechPadMs, vadSpeechPadMs) || other.vadSpeechPadMs == vadSpeechPadMs));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,audio,isTranslate,threads,isVerbose,language,isSpecialTokens,isNoTimestamps,isRealtime,nProcessors,splitOnWord,noFallback,diarize,speedUp,realtimeStream,initialPrompt,noContext,suppressNonSpeechTokens,keepModelLoaded);
+int get hashCode => Object.hashAll([runtimeType,audio,isTranslate,threads,isVerbose,language,isSpecialTokens,isNoTimestamps,isRealtime,nProcessors,splitOnWord,noFallback,diarize,speedUp,realtimeStream,initialPrompt,noContext,suppressNonSpeechTokens,keepModelLoaded,vadModelPath,vadSpeechPadMs]);
 
 @override
 String toString() {
-  return 'TranscribeRequest(audio: $audio, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, isRealtime: $isRealtime, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, diarize: $diarize, speedUp: $speedUp, realtimeStream: $realtimeStream, initialPrompt: $initialPrompt, noContext: $noContext, suppressNonSpeechTokens: $suppressNonSpeechTokens, keepModelLoaded: $keepModelLoaded)';
+  return 'TranscribeRequest(audio: $audio, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, isRealtime: $isRealtime, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, diarize: $diarize, speedUp: $speedUp, realtimeStream: $realtimeStream, initialPrompt: $initialPrompt, noContext: $noContext, suppressNonSpeechTokens: $suppressNonSpeechTokens, keepModelLoaded: $keepModelLoaded, vadModelPath: $vadModelPath, vadSpeechPadMs: $vadSpeechPadMs)';
 }
 
 
@@ -385,7 +423,7 @@ abstract mixin class _$TranscribeRequestCopyWith<$Res> implements $TranscribeReq
   factory _$TranscribeRequestCopyWith(_TranscribeRequest value, $Res Function(_TranscribeRequest) _then) = __$TranscribeRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String audio, bool isTranslate, int threads, bool isVerbose, String language, bool isSpecialTokens, bool isNoTimestamps, bool isRealtime, int nProcessors, bool splitOnWord, bool noFallback, bool diarize, bool speedUp, Stream<String>? realtimeStream, String? initialPrompt, bool noContext, bool suppressNonSpeechTokens, bool keepModelLoaded
+ String audio, bool isTranslate, int threads, bool isVerbose, String language, bool isSpecialTokens, bool isNoTimestamps, bool isRealtime, int nProcessors, bool splitOnWord, bool noFallback, bool diarize, bool speedUp, Stream<String>? realtimeStream, String? initialPrompt, bool noContext, bool suppressNonSpeechTokens, bool keepModelLoaded, String? vadModelPath, int? vadSpeechPadMs
 });
 
 
@@ -402,7 +440,7 @@ class __$TranscribeRequestCopyWithImpl<$Res>
 
 /// Create a copy of TranscribeRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? audio = null,Object? isTranslate = null,Object? threads = null,Object? isVerbose = null,Object? language = null,Object? isSpecialTokens = null,Object? isNoTimestamps = null,Object? isRealtime = null,Object? nProcessors = null,Object? splitOnWord = null,Object? noFallback = null,Object? diarize = null,Object? speedUp = null,Object? realtimeStream = freezed,Object? initialPrompt = freezed,Object? noContext = null,Object? suppressNonSpeechTokens = null,Object? keepModelLoaded = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? audio = null,Object? isTranslate = null,Object? threads = null,Object? isVerbose = null,Object? language = null,Object? isSpecialTokens = null,Object? isNoTimestamps = null,Object? isRealtime = null,Object? nProcessors = null,Object? splitOnWord = null,Object? noFallback = null,Object? diarize = null,Object? speedUp = null,Object? realtimeStream = freezed,Object? initialPrompt = freezed,Object? noContext = null,Object? suppressNonSpeechTokens = null,Object? keepModelLoaded = null,Object? vadModelPath = freezed,Object? vadSpeechPadMs = freezed,}) {
   return _then(_TranscribeRequest(
 audio: null == audio ? _self.audio : audio // ignore: cast_nullable_to_non_nullable
 as String,isTranslate: null == isTranslate ? _self.isTranslate : isTranslate // ignore: cast_nullable_to_non_nullable
@@ -422,7 +460,9 @@ as Stream<String>?,initialPrompt: freezed == initialPrompt ? _self.initialPrompt
 as String?,noContext: null == noContext ? _self.noContext : noContext // ignore: cast_nullable_to_non_nullable
 as bool,suppressNonSpeechTokens: null == suppressNonSpeechTokens ? _self.suppressNonSpeechTokens : suppressNonSpeechTokens // ignore: cast_nullable_to_non_nullable
 as bool,keepModelLoaded: null == keepModelLoaded ? _self.keepModelLoaded : keepModelLoaded // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,vadModelPath: freezed == vadModelPath ? _self.vadModelPath : vadModelPath // ignore: cast_nullable_to_non_nullable
+as String?,vadSpeechPadMs: freezed == vadSpeechPadMs ? _self.vadSpeechPadMs : vadSpeechPadMs // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 

--- a/lib/src/models/requests/transcribe_request_dto.dart
+++ b/lib/src/models/requests/transcribe_request_dto.dart
@@ -40,6 +40,12 @@ abstract class TranscribeRequestDto
     /// invokes with transcription progress (0–100); null disables it.
     @JsonKey(name: 'progress_callback') int? progressCallback,
     @JsonKey(name: 'keep_model_loaded') @Default(false) bool keepModelLoaded,
+
+    /// Silero VAD model path; null leaves VAD off on the native side.
+    @JsonKey(name: 'vad_model') String? vadModel,
+
+    /// speech_pad_ms override; null keeps whisper.cpp's default.
+    @JsonKey(name: 'vad_speech_pad_ms') int? vadSpeechPadMs,
   }) = _TranscribeRequestDto;
 
   /// Convert [request] to TranscribeRequestDto with specified [modelPath]
@@ -68,6 +74,8 @@ abstract class TranscribeRequestDto
       suppressNonSpeechTokens: request.suppressNonSpeechTokens,
       progressCallback: progressCallbackAddress,
       keepModelLoaded: request.keepModelLoaded,
+      vadModel: request.vadModelPath,
+      vadSpeechPadMs: request.vadSpeechPadMs,
     );
   }
   const TranscribeRequestDto._();

--- a/lib/src/models/requests/transcribe_request_dto.freezed.dart
+++ b/lib/src/models/requests/transcribe_request_dto.freezed.dart
@@ -17,7 +17,9 @@ mixin _$TranscribeRequestDto {
 
  String get audio; String get model;@JsonKey(name: 'is_translate') bool get isTranslate; int get threads;@JsonKey(name: 'is_verbose') bool get isVerbose; String get language;@JsonKey(name: 'is_special_tokens') bool get isSpecialTokens;@JsonKey(name: 'is_no_timestamps') bool get isNoTimestamps;@JsonKey(name: 'n_processors') int get nProcessors;@JsonKey(name: 'split_on_word') bool get splitOnWord;@JsonKey(name: 'no_fallback') bool get noFallback;@JsonKey(name: 'is_realtime') bool get isRealtime; bool get diarize;@JsonKey(name: 'speed_up') bool get speedUp;@JsonKey(name: 'initial_prompt') String? get initialPrompt;@JsonKey(name: 'no_context') bool get noContext;@JsonKey(name: 'suppress_non_speech_tokens') bool get suppressNonSpeechTokens;/// Address of a `NativeCallable<Void Function(Int32)>` the native layer
 /// invokes with transcription progress (0–100); null disables it.
-@JsonKey(name: 'progress_callback') int? get progressCallback;@JsonKey(name: 'keep_model_loaded') bool get keepModelLoaded;
+@JsonKey(name: 'progress_callback') int? get progressCallback;@JsonKey(name: 'keep_model_loaded') bool get keepModelLoaded;/// Silero VAD model path; null leaves VAD off on the native side.
+@JsonKey(name: 'vad_model') String? get vadModel;/// speech_pad_ms override; null keeps whisper.cpp's default.
+@JsonKey(name: 'vad_speech_pad_ms') int? get vadSpeechPadMs;
 /// Create a copy of TranscribeRequestDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -30,16 +32,16 @@ $TranscribeRequestDtoCopyWith<TranscribeRequestDto> get copyWith => _$Transcribe
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is TranscribeRequestDto&&(identical(other.audio, audio) || other.audio == audio)&&(identical(other.model, model) || other.model == model)&&(identical(other.isTranslate, isTranslate) || other.isTranslate == isTranslate)&&(identical(other.threads, threads) || other.threads == threads)&&(identical(other.isVerbose, isVerbose) || other.isVerbose == isVerbose)&&(identical(other.language, language) || other.language == language)&&(identical(other.isSpecialTokens, isSpecialTokens) || other.isSpecialTokens == isSpecialTokens)&&(identical(other.isNoTimestamps, isNoTimestamps) || other.isNoTimestamps == isNoTimestamps)&&(identical(other.nProcessors, nProcessors) || other.nProcessors == nProcessors)&&(identical(other.splitOnWord, splitOnWord) || other.splitOnWord == splitOnWord)&&(identical(other.noFallback, noFallback) || other.noFallback == noFallback)&&(identical(other.isRealtime, isRealtime) || other.isRealtime == isRealtime)&&(identical(other.diarize, diarize) || other.diarize == diarize)&&(identical(other.speedUp, speedUp) || other.speedUp == speedUp)&&(identical(other.initialPrompt, initialPrompt) || other.initialPrompt == initialPrompt)&&(identical(other.noContext, noContext) || other.noContext == noContext)&&(identical(other.suppressNonSpeechTokens, suppressNonSpeechTokens) || other.suppressNonSpeechTokens == suppressNonSpeechTokens)&&(identical(other.progressCallback, progressCallback) || other.progressCallback == progressCallback)&&(identical(other.keepModelLoaded, keepModelLoaded) || other.keepModelLoaded == keepModelLoaded));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TranscribeRequestDto&&(identical(other.audio, audio) || other.audio == audio)&&(identical(other.model, model) || other.model == model)&&(identical(other.isTranslate, isTranslate) || other.isTranslate == isTranslate)&&(identical(other.threads, threads) || other.threads == threads)&&(identical(other.isVerbose, isVerbose) || other.isVerbose == isVerbose)&&(identical(other.language, language) || other.language == language)&&(identical(other.isSpecialTokens, isSpecialTokens) || other.isSpecialTokens == isSpecialTokens)&&(identical(other.isNoTimestamps, isNoTimestamps) || other.isNoTimestamps == isNoTimestamps)&&(identical(other.nProcessors, nProcessors) || other.nProcessors == nProcessors)&&(identical(other.splitOnWord, splitOnWord) || other.splitOnWord == splitOnWord)&&(identical(other.noFallback, noFallback) || other.noFallback == noFallback)&&(identical(other.isRealtime, isRealtime) || other.isRealtime == isRealtime)&&(identical(other.diarize, diarize) || other.diarize == diarize)&&(identical(other.speedUp, speedUp) || other.speedUp == speedUp)&&(identical(other.initialPrompt, initialPrompt) || other.initialPrompt == initialPrompt)&&(identical(other.noContext, noContext) || other.noContext == noContext)&&(identical(other.suppressNonSpeechTokens, suppressNonSpeechTokens) || other.suppressNonSpeechTokens == suppressNonSpeechTokens)&&(identical(other.progressCallback, progressCallback) || other.progressCallback == progressCallback)&&(identical(other.keepModelLoaded, keepModelLoaded) || other.keepModelLoaded == keepModelLoaded)&&(identical(other.vadModel, vadModel) || other.vadModel == vadModel)&&(identical(other.vadSpeechPadMs, vadSpeechPadMs) || other.vadSpeechPadMs == vadSpeechPadMs));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,audio,model,isTranslate,threads,isVerbose,language,isSpecialTokens,isNoTimestamps,nProcessors,splitOnWord,noFallback,isRealtime,diarize,speedUp,initialPrompt,noContext,suppressNonSpeechTokens,progressCallback,keepModelLoaded]);
+int get hashCode => Object.hashAll([runtimeType,audio,model,isTranslate,threads,isVerbose,language,isSpecialTokens,isNoTimestamps,nProcessors,splitOnWord,noFallback,isRealtime,diarize,speedUp,initialPrompt,noContext,suppressNonSpeechTokens,progressCallback,keepModelLoaded,vadModel,vadSpeechPadMs]);
 
 @override
 String toString() {
-  return 'TranscribeRequestDto(audio: $audio, model: $model, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, isRealtime: $isRealtime, diarize: $diarize, speedUp: $speedUp, initialPrompt: $initialPrompt, noContext: $noContext, suppressNonSpeechTokens: $suppressNonSpeechTokens, progressCallback: $progressCallback, keepModelLoaded: $keepModelLoaded)';
+  return 'TranscribeRequestDto(audio: $audio, model: $model, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, isRealtime: $isRealtime, diarize: $diarize, speedUp: $speedUp, initialPrompt: $initialPrompt, noContext: $noContext, suppressNonSpeechTokens: $suppressNonSpeechTokens, progressCallback: $progressCallback, keepModelLoaded: $keepModelLoaded, vadModel: $vadModel, vadSpeechPadMs: $vadSpeechPadMs)';
 }
 
 
@@ -50,7 +52,7 @@ abstract mixin class $TranscribeRequestDtoCopyWith<$Res>  {
   factory $TranscribeRequestDtoCopyWith(TranscribeRequestDto value, $Res Function(TranscribeRequestDto) _then) = _$TranscribeRequestDtoCopyWithImpl;
 @useResult
 $Res call({
- String audio, String model,@JsonKey(name: 'is_translate') bool isTranslate, int threads,@JsonKey(name: 'is_verbose') bool isVerbose, String language,@JsonKey(name: 'is_special_tokens') bool isSpecialTokens,@JsonKey(name: 'is_no_timestamps') bool isNoTimestamps,@JsonKey(name: 'n_processors') int nProcessors,@JsonKey(name: 'split_on_word') bool splitOnWord,@JsonKey(name: 'no_fallback') bool noFallback,@JsonKey(name: 'is_realtime') bool isRealtime, bool diarize,@JsonKey(name: 'speed_up') bool speedUp,@JsonKey(name: 'initial_prompt') String? initialPrompt,@JsonKey(name: 'no_context') bool noContext,@JsonKey(name: 'suppress_non_speech_tokens') bool suppressNonSpeechTokens,@JsonKey(name: 'progress_callback') int? progressCallback,@JsonKey(name: 'keep_model_loaded') bool keepModelLoaded
+ String audio, String model,@JsonKey(name: 'is_translate') bool isTranslate, int threads,@JsonKey(name: 'is_verbose') bool isVerbose, String language,@JsonKey(name: 'is_special_tokens') bool isSpecialTokens,@JsonKey(name: 'is_no_timestamps') bool isNoTimestamps,@JsonKey(name: 'n_processors') int nProcessors,@JsonKey(name: 'split_on_word') bool splitOnWord,@JsonKey(name: 'no_fallback') bool noFallback,@JsonKey(name: 'is_realtime') bool isRealtime, bool diarize,@JsonKey(name: 'speed_up') bool speedUp,@JsonKey(name: 'initial_prompt') String? initialPrompt,@JsonKey(name: 'no_context') bool noContext,@JsonKey(name: 'suppress_non_speech_tokens') bool suppressNonSpeechTokens,@JsonKey(name: 'progress_callback') int? progressCallback,@JsonKey(name: 'keep_model_loaded') bool keepModelLoaded,@JsonKey(name: 'vad_model') String? vadModel,@JsonKey(name: 'vad_speech_pad_ms') int? vadSpeechPadMs
 });
 
 
@@ -67,7 +69,7 @@ class _$TranscribeRequestDtoCopyWithImpl<$Res>
 
 /// Create a copy of TranscribeRequestDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? audio = null,Object? model = null,Object? isTranslate = null,Object? threads = null,Object? isVerbose = null,Object? language = null,Object? isSpecialTokens = null,Object? isNoTimestamps = null,Object? nProcessors = null,Object? splitOnWord = null,Object? noFallback = null,Object? isRealtime = null,Object? diarize = null,Object? speedUp = null,Object? initialPrompt = freezed,Object? noContext = null,Object? suppressNonSpeechTokens = null,Object? progressCallback = freezed,Object? keepModelLoaded = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? audio = null,Object? model = null,Object? isTranslate = null,Object? threads = null,Object? isVerbose = null,Object? language = null,Object? isSpecialTokens = null,Object? isNoTimestamps = null,Object? nProcessors = null,Object? splitOnWord = null,Object? noFallback = null,Object? isRealtime = null,Object? diarize = null,Object? speedUp = null,Object? initialPrompt = freezed,Object? noContext = null,Object? suppressNonSpeechTokens = null,Object? progressCallback = freezed,Object? keepModelLoaded = null,Object? vadModel = freezed,Object? vadSpeechPadMs = freezed,}) {
   return _then(_self.copyWith(
 audio: null == audio ? _self.audio : audio // ignore: cast_nullable_to_non_nullable
 as String,model: null == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
@@ -88,7 +90,9 @@ as String?,noContext: null == noContext ? _self.noContext : noContext // ignore:
 as bool,suppressNonSpeechTokens: null == suppressNonSpeechTokens ? _self.suppressNonSpeechTokens : suppressNonSpeechTokens // ignore: cast_nullable_to_non_nullable
 as bool,progressCallback: freezed == progressCallback ? _self.progressCallback : progressCallback // ignore: cast_nullable_to_non_nullable
 as int?,keepModelLoaded: null == keepModelLoaded ? _self.keepModelLoaded : keepModelLoaded // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,vadModel: freezed == vadModel ? _self.vadModel : vadModel // ignore: cast_nullable_to_non_nullable
+as String?,vadSpeechPadMs: freezed == vadSpeechPadMs ? _self.vadSpeechPadMs : vadSpeechPadMs // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 
@@ -173,10 +177,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String audio,  String model, @JsonKey(name: 'is_translate')  bool isTranslate,  int threads, @JsonKey(name: 'is_verbose')  bool isVerbose,  String language, @JsonKey(name: 'is_special_tokens')  bool isSpecialTokens, @JsonKey(name: 'is_no_timestamps')  bool isNoTimestamps, @JsonKey(name: 'n_processors')  int nProcessors, @JsonKey(name: 'split_on_word')  bool splitOnWord, @JsonKey(name: 'no_fallback')  bool noFallback, @JsonKey(name: 'is_realtime')  bool isRealtime,  bool diarize, @JsonKey(name: 'speed_up')  bool speedUp, @JsonKey(name: 'initial_prompt')  String? initialPrompt, @JsonKey(name: 'no_context')  bool noContext, @JsonKey(name: 'suppress_non_speech_tokens')  bool suppressNonSpeechTokens, @JsonKey(name: 'progress_callback')  int? progressCallback, @JsonKey(name: 'keep_model_loaded')  bool keepModelLoaded)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String audio,  String model, @JsonKey(name: 'is_translate')  bool isTranslate,  int threads, @JsonKey(name: 'is_verbose')  bool isVerbose,  String language, @JsonKey(name: 'is_special_tokens')  bool isSpecialTokens, @JsonKey(name: 'is_no_timestamps')  bool isNoTimestamps, @JsonKey(name: 'n_processors')  int nProcessors, @JsonKey(name: 'split_on_word')  bool splitOnWord, @JsonKey(name: 'no_fallback')  bool noFallback, @JsonKey(name: 'is_realtime')  bool isRealtime,  bool diarize, @JsonKey(name: 'speed_up')  bool speedUp, @JsonKey(name: 'initial_prompt')  String? initialPrompt, @JsonKey(name: 'no_context')  bool noContext, @JsonKey(name: 'suppress_non_speech_tokens')  bool suppressNonSpeechTokens, @JsonKey(name: 'progress_callback')  int? progressCallback, @JsonKey(name: 'keep_model_loaded')  bool keepModelLoaded, @JsonKey(name: 'vad_model')  String? vadModel, @JsonKey(name: 'vad_speech_pad_ms')  int? vadSpeechPadMs)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _TranscribeRequestDto() when $default != null:
-return $default(_that.audio,_that.model,_that.isTranslate,_that.threads,_that.isVerbose,_that.language,_that.isSpecialTokens,_that.isNoTimestamps,_that.nProcessors,_that.splitOnWord,_that.noFallback,_that.isRealtime,_that.diarize,_that.speedUp,_that.initialPrompt,_that.noContext,_that.suppressNonSpeechTokens,_that.progressCallback,_that.keepModelLoaded);case _:
+return $default(_that.audio,_that.model,_that.isTranslate,_that.threads,_that.isVerbose,_that.language,_that.isSpecialTokens,_that.isNoTimestamps,_that.nProcessors,_that.splitOnWord,_that.noFallback,_that.isRealtime,_that.diarize,_that.speedUp,_that.initialPrompt,_that.noContext,_that.suppressNonSpeechTokens,_that.progressCallback,_that.keepModelLoaded,_that.vadModel,_that.vadSpeechPadMs);case _:
   return orElse();
 
 }
@@ -194,10 +198,10 @@ return $default(_that.audio,_that.model,_that.isTranslate,_that.threads,_that.is
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String audio,  String model, @JsonKey(name: 'is_translate')  bool isTranslate,  int threads, @JsonKey(name: 'is_verbose')  bool isVerbose,  String language, @JsonKey(name: 'is_special_tokens')  bool isSpecialTokens, @JsonKey(name: 'is_no_timestamps')  bool isNoTimestamps, @JsonKey(name: 'n_processors')  int nProcessors, @JsonKey(name: 'split_on_word')  bool splitOnWord, @JsonKey(name: 'no_fallback')  bool noFallback, @JsonKey(name: 'is_realtime')  bool isRealtime,  bool diarize, @JsonKey(name: 'speed_up')  bool speedUp, @JsonKey(name: 'initial_prompt')  String? initialPrompt, @JsonKey(name: 'no_context')  bool noContext, @JsonKey(name: 'suppress_non_speech_tokens')  bool suppressNonSpeechTokens, @JsonKey(name: 'progress_callback')  int? progressCallback, @JsonKey(name: 'keep_model_loaded')  bool keepModelLoaded)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String audio,  String model, @JsonKey(name: 'is_translate')  bool isTranslate,  int threads, @JsonKey(name: 'is_verbose')  bool isVerbose,  String language, @JsonKey(name: 'is_special_tokens')  bool isSpecialTokens, @JsonKey(name: 'is_no_timestamps')  bool isNoTimestamps, @JsonKey(name: 'n_processors')  int nProcessors, @JsonKey(name: 'split_on_word')  bool splitOnWord, @JsonKey(name: 'no_fallback')  bool noFallback, @JsonKey(name: 'is_realtime')  bool isRealtime,  bool diarize, @JsonKey(name: 'speed_up')  bool speedUp, @JsonKey(name: 'initial_prompt')  String? initialPrompt, @JsonKey(name: 'no_context')  bool noContext, @JsonKey(name: 'suppress_non_speech_tokens')  bool suppressNonSpeechTokens, @JsonKey(name: 'progress_callback')  int? progressCallback, @JsonKey(name: 'keep_model_loaded')  bool keepModelLoaded, @JsonKey(name: 'vad_model')  String? vadModel, @JsonKey(name: 'vad_speech_pad_ms')  int? vadSpeechPadMs)  $default,) {final _that = this;
 switch (_that) {
 case _TranscribeRequestDto():
-return $default(_that.audio,_that.model,_that.isTranslate,_that.threads,_that.isVerbose,_that.language,_that.isSpecialTokens,_that.isNoTimestamps,_that.nProcessors,_that.splitOnWord,_that.noFallback,_that.isRealtime,_that.diarize,_that.speedUp,_that.initialPrompt,_that.noContext,_that.suppressNonSpeechTokens,_that.progressCallback,_that.keepModelLoaded);case _:
+return $default(_that.audio,_that.model,_that.isTranslate,_that.threads,_that.isVerbose,_that.language,_that.isSpecialTokens,_that.isNoTimestamps,_that.nProcessors,_that.splitOnWord,_that.noFallback,_that.isRealtime,_that.diarize,_that.speedUp,_that.initialPrompt,_that.noContext,_that.suppressNonSpeechTokens,_that.progressCallback,_that.keepModelLoaded,_that.vadModel,_that.vadSpeechPadMs);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -214,10 +218,10 @@ return $default(_that.audio,_that.model,_that.isTranslate,_that.threads,_that.is
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String audio,  String model, @JsonKey(name: 'is_translate')  bool isTranslate,  int threads, @JsonKey(name: 'is_verbose')  bool isVerbose,  String language, @JsonKey(name: 'is_special_tokens')  bool isSpecialTokens, @JsonKey(name: 'is_no_timestamps')  bool isNoTimestamps, @JsonKey(name: 'n_processors')  int nProcessors, @JsonKey(name: 'split_on_word')  bool splitOnWord, @JsonKey(name: 'no_fallback')  bool noFallback, @JsonKey(name: 'is_realtime')  bool isRealtime,  bool diarize, @JsonKey(name: 'speed_up')  bool speedUp, @JsonKey(name: 'initial_prompt')  String? initialPrompt, @JsonKey(name: 'no_context')  bool noContext, @JsonKey(name: 'suppress_non_speech_tokens')  bool suppressNonSpeechTokens, @JsonKey(name: 'progress_callback')  int? progressCallback, @JsonKey(name: 'keep_model_loaded')  bool keepModelLoaded)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String audio,  String model, @JsonKey(name: 'is_translate')  bool isTranslate,  int threads, @JsonKey(name: 'is_verbose')  bool isVerbose,  String language, @JsonKey(name: 'is_special_tokens')  bool isSpecialTokens, @JsonKey(name: 'is_no_timestamps')  bool isNoTimestamps, @JsonKey(name: 'n_processors')  int nProcessors, @JsonKey(name: 'split_on_word')  bool splitOnWord, @JsonKey(name: 'no_fallback')  bool noFallback, @JsonKey(name: 'is_realtime')  bool isRealtime,  bool diarize, @JsonKey(name: 'speed_up')  bool speedUp, @JsonKey(name: 'initial_prompt')  String? initialPrompt, @JsonKey(name: 'no_context')  bool noContext, @JsonKey(name: 'suppress_non_speech_tokens')  bool suppressNonSpeechTokens, @JsonKey(name: 'progress_callback')  int? progressCallback, @JsonKey(name: 'keep_model_loaded')  bool keepModelLoaded, @JsonKey(name: 'vad_model')  String? vadModel, @JsonKey(name: 'vad_speech_pad_ms')  int? vadSpeechPadMs)?  $default,) {final _that = this;
 switch (_that) {
 case _TranscribeRequestDto() when $default != null:
-return $default(_that.audio,_that.model,_that.isTranslate,_that.threads,_that.isVerbose,_that.language,_that.isSpecialTokens,_that.isNoTimestamps,_that.nProcessors,_that.splitOnWord,_that.noFallback,_that.isRealtime,_that.diarize,_that.speedUp,_that.initialPrompt,_that.noContext,_that.suppressNonSpeechTokens,_that.progressCallback,_that.keepModelLoaded);case _:
+return $default(_that.audio,_that.model,_that.isTranslate,_that.threads,_that.isVerbose,_that.language,_that.isSpecialTokens,_that.isNoTimestamps,_that.nProcessors,_that.splitOnWord,_that.noFallback,_that.isRealtime,_that.diarize,_that.speedUp,_that.initialPrompt,_that.noContext,_that.suppressNonSpeechTokens,_that.progressCallback,_that.keepModelLoaded,_that.vadModel,_that.vadSpeechPadMs);case _:
   return null;
 
 }
@@ -229,7 +233,7 @@ return $default(_that.audio,_that.model,_that.isTranslate,_that.threads,_that.is
 @JsonSerializable()
 
 class _TranscribeRequestDto extends TranscribeRequestDto {
-  const _TranscribeRequestDto({required this.audio, required this.model, @JsonKey(name: 'is_translate') required this.isTranslate, required this.threads, @JsonKey(name: 'is_verbose') required this.isVerbose, required this.language, @JsonKey(name: 'is_special_tokens') required this.isSpecialTokens, @JsonKey(name: 'is_no_timestamps') required this.isNoTimestamps, @JsonKey(name: 'n_processors') required this.nProcessors, @JsonKey(name: 'split_on_word') required this.splitOnWord, @JsonKey(name: 'no_fallback') required this.noFallback, @JsonKey(name: 'is_realtime') required this.isRealtime, required this.diarize, @JsonKey(name: 'speed_up') required this.speedUp, @JsonKey(name: 'initial_prompt') this.initialPrompt, @JsonKey(name: 'no_context') this.noContext = false, @JsonKey(name: 'suppress_non_speech_tokens') this.suppressNonSpeechTokens = false, @JsonKey(name: 'progress_callback') this.progressCallback, @JsonKey(name: 'keep_model_loaded') this.keepModelLoaded = false}): super._();
+  const _TranscribeRequestDto({required this.audio, required this.model, @JsonKey(name: 'is_translate') required this.isTranslate, required this.threads, @JsonKey(name: 'is_verbose') required this.isVerbose, required this.language, @JsonKey(name: 'is_special_tokens') required this.isSpecialTokens, @JsonKey(name: 'is_no_timestamps') required this.isNoTimestamps, @JsonKey(name: 'n_processors') required this.nProcessors, @JsonKey(name: 'split_on_word') required this.splitOnWord, @JsonKey(name: 'no_fallback') required this.noFallback, @JsonKey(name: 'is_realtime') required this.isRealtime, required this.diarize, @JsonKey(name: 'speed_up') required this.speedUp, @JsonKey(name: 'initial_prompt') this.initialPrompt, @JsonKey(name: 'no_context') this.noContext = false, @JsonKey(name: 'suppress_non_speech_tokens') this.suppressNonSpeechTokens = false, @JsonKey(name: 'progress_callback') this.progressCallback, @JsonKey(name: 'keep_model_loaded') this.keepModelLoaded = false, @JsonKey(name: 'vad_model') this.vadModel, @JsonKey(name: 'vad_speech_pad_ms') this.vadSpeechPadMs}): super._();
   factory _TranscribeRequestDto.fromJson(Map<String, dynamic> json) => _$TranscribeRequestDtoFromJson(json);
 
 @override final  String audio;
@@ -253,6 +257,10 @@ class _TranscribeRequestDto extends TranscribeRequestDto {
 /// invokes with transcription progress (0–100); null disables it.
 @override@JsonKey(name: 'progress_callback') final  int? progressCallback;
 @override@JsonKey(name: 'keep_model_loaded') final  bool keepModelLoaded;
+/// Silero VAD model path; null leaves VAD off on the native side.
+@override@JsonKey(name: 'vad_model') final  String? vadModel;
+/// speech_pad_ms override; null keeps whisper.cpp's default.
+@override@JsonKey(name: 'vad_speech_pad_ms') final  int? vadSpeechPadMs;
 
 /// Create a copy of TranscribeRequestDto
 /// with the given fields replaced by the non-null parameter values.
@@ -267,16 +275,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TranscribeRequestDto&&(identical(other.audio, audio) || other.audio == audio)&&(identical(other.model, model) || other.model == model)&&(identical(other.isTranslate, isTranslate) || other.isTranslate == isTranslate)&&(identical(other.threads, threads) || other.threads == threads)&&(identical(other.isVerbose, isVerbose) || other.isVerbose == isVerbose)&&(identical(other.language, language) || other.language == language)&&(identical(other.isSpecialTokens, isSpecialTokens) || other.isSpecialTokens == isSpecialTokens)&&(identical(other.isNoTimestamps, isNoTimestamps) || other.isNoTimestamps == isNoTimestamps)&&(identical(other.nProcessors, nProcessors) || other.nProcessors == nProcessors)&&(identical(other.splitOnWord, splitOnWord) || other.splitOnWord == splitOnWord)&&(identical(other.noFallback, noFallback) || other.noFallback == noFallback)&&(identical(other.isRealtime, isRealtime) || other.isRealtime == isRealtime)&&(identical(other.diarize, diarize) || other.diarize == diarize)&&(identical(other.speedUp, speedUp) || other.speedUp == speedUp)&&(identical(other.initialPrompt, initialPrompt) || other.initialPrompt == initialPrompt)&&(identical(other.noContext, noContext) || other.noContext == noContext)&&(identical(other.suppressNonSpeechTokens, suppressNonSpeechTokens) || other.suppressNonSpeechTokens == suppressNonSpeechTokens)&&(identical(other.progressCallback, progressCallback) || other.progressCallback == progressCallback)&&(identical(other.keepModelLoaded, keepModelLoaded) || other.keepModelLoaded == keepModelLoaded));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TranscribeRequestDto&&(identical(other.audio, audio) || other.audio == audio)&&(identical(other.model, model) || other.model == model)&&(identical(other.isTranslate, isTranslate) || other.isTranslate == isTranslate)&&(identical(other.threads, threads) || other.threads == threads)&&(identical(other.isVerbose, isVerbose) || other.isVerbose == isVerbose)&&(identical(other.language, language) || other.language == language)&&(identical(other.isSpecialTokens, isSpecialTokens) || other.isSpecialTokens == isSpecialTokens)&&(identical(other.isNoTimestamps, isNoTimestamps) || other.isNoTimestamps == isNoTimestamps)&&(identical(other.nProcessors, nProcessors) || other.nProcessors == nProcessors)&&(identical(other.splitOnWord, splitOnWord) || other.splitOnWord == splitOnWord)&&(identical(other.noFallback, noFallback) || other.noFallback == noFallback)&&(identical(other.isRealtime, isRealtime) || other.isRealtime == isRealtime)&&(identical(other.diarize, diarize) || other.diarize == diarize)&&(identical(other.speedUp, speedUp) || other.speedUp == speedUp)&&(identical(other.initialPrompt, initialPrompt) || other.initialPrompt == initialPrompt)&&(identical(other.noContext, noContext) || other.noContext == noContext)&&(identical(other.suppressNonSpeechTokens, suppressNonSpeechTokens) || other.suppressNonSpeechTokens == suppressNonSpeechTokens)&&(identical(other.progressCallback, progressCallback) || other.progressCallback == progressCallback)&&(identical(other.keepModelLoaded, keepModelLoaded) || other.keepModelLoaded == keepModelLoaded)&&(identical(other.vadModel, vadModel) || other.vadModel == vadModel)&&(identical(other.vadSpeechPadMs, vadSpeechPadMs) || other.vadSpeechPadMs == vadSpeechPadMs));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,audio,model,isTranslate,threads,isVerbose,language,isSpecialTokens,isNoTimestamps,nProcessors,splitOnWord,noFallback,isRealtime,diarize,speedUp,initialPrompt,noContext,suppressNonSpeechTokens,progressCallback,keepModelLoaded]);
+int get hashCode => Object.hashAll([runtimeType,audio,model,isTranslate,threads,isVerbose,language,isSpecialTokens,isNoTimestamps,nProcessors,splitOnWord,noFallback,isRealtime,diarize,speedUp,initialPrompt,noContext,suppressNonSpeechTokens,progressCallback,keepModelLoaded,vadModel,vadSpeechPadMs]);
 
 @override
 String toString() {
-  return 'TranscribeRequestDto(audio: $audio, model: $model, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, isRealtime: $isRealtime, diarize: $diarize, speedUp: $speedUp, initialPrompt: $initialPrompt, noContext: $noContext, suppressNonSpeechTokens: $suppressNonSpeechTokens, progressCallback: $progressCallback, keepModelLoaded: $keepModelLoaded)';
+  return 'TranscribeRequestDto(audio: $audio, model: $model, isTranslate: $isTranslate, threads: $threads, isVerbose: $isVerbose, language: $language, isSpecialTokens: $isSpecialTokens, isNoTimestamps: $isNoTimestamps, nProcessors: $nProcessors, splitOnWord: $splitOnWord, noFallback: $noFallback, isRealtime: $isRealtime, diarize: $diarize, speedUp: $speedUp, initialPrompt: $initialPrompt, noContext: $noContext, suppressNonSpeechTokens: $suppressNonSpeechTokens, progressCallback: $progressCallback, keepModelLoaded: $keepModelLoaded, vadModel: $vadModel, vadSpeechPadMs: $vadSpeechPadMs)';
 }
 
 
@@ -287,7 +295,7 @@ abstract mixin class _$TranscribeRequestDtoCopyWith<$Res> implements $Transcribe
   factory _$TranscribeRequestDtoCopyWith(_TranscribeRequestDto value, $Res Function(_TranscribeRequestDto) _then) = __$TranscribeRequestDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String audio, String model,@JsonKey(name: 'is_translate') bool isTranslate, int threads,@JsonKey(name: 'is_verbose') bool isVerbose, String language,@JsonKey(name: 'is_special_tokens') bool isSpecialTokens,@JsonKey(name: 'is_no_timestamps') bool isNoTimestamps,@JsonKey(name: 'n_processors') int nProcessors,@JsonKey(name: 'split_on_word') bool splitOnWord,@JsonKey(name: 'no_fallback') bool noFallback,@JsonKey(name: 'is_realtime') bool isRealtime, bool diarize,@JsonKey(name: 'speed_up') bool speedUp,@JsonKey(name: 'initial_prompt') String? initialPrompt,@JsonKey(name: 'no_context') bool noContext,@JsonKey(name: 'suppress_non_speech_tokens') bool suppressNonSpeechTokens,@JsonKey(name: 'progress_callback') int? progressCallback,@JsonKey(name: 'keep_model_loaded') bool keepModelLoaded
+ String audio, String model,@JsonKey(name: 'is_translate') bool isTranslate, int threads,@JsonKey(name: 'is_verbose') bool isVerbose, String language,@JsonKey(name: 'is_special_tokens') bool isSpecialTokens,@JsonKey(name: 'is_no_timestamps') bool isNoTimestamps,@JsonKey(name: 'n_processors') int nProcessors,@JsonKey(name: 'split_on_word') bool splitOnWord,@JsonKey(name: 'no_fallback') bool noFallback,@JsonKey(name: 'is_realtime') bool isRealtime, bool diarize,@JsonKey(name: 'speed_up') bool speedUp,@JsonKey(name: 'initial_prompt') String? initialPrompt,@JsonKey(name: 'no_context') bool noContext,@JsonKey(name: 'suppress_non_speech_tokens') bool suppressNonSpeechTokens,@JsonKey(name: 'progress_callback') int? progressCallback,@JsonKey(name: 'keep_model_loaded') bool keepModelLoaded,@JsonKey(name: 'vad_model') String? vadModel,@JsonKey(name: 'vad_speech_pad_ms') int? vadSpeechPadMs
 });
 
 
@@ -304,7 +312,7 @@ class __$TranscribeRequestDtoCopyWithImpl<$Res>
 
 /// Create a copy of TranscribeRequestDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? audio = null,Object? model = null,Object? isTranslate = null,Object? threads = null,Object? isVerbose = null,Object? language = null,Object? isSpecialTokens = null,Object? isNoTimestamps = null,Object? nProcessors = null,Object? splitOnWord = null,Object? noFallback = null,Object? isRealtime = null,Object? diarize = null,Object? speedUp = null,Object? initialPrompt = freezed,Object? noContext = null,Object? suppressNonSpeechTokens = null,Object? progressCallback = freezed,Object? keepModelLoaded = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? audio = null,Object? model = null,Object? isTranslate = null,Object? threads = null,Object? isVerbose = null,Object? language = null,Object? isSpecialTokens = null,Object? isNoTimestamps = null,Object? nProcessors = null,Object? splitOnWord = null,Object? noFallback = null,Object? isRealtime = null,Object? diarize = null,Object? speedUp = null,Object? initialPrompt = freezed,Object? noContext = null,Object? suppressNonSpeechTokens = null,Object? progressCallback = freezed,Object? keepModelLoaded = null,Object? vadModel = freezed,Object? vadSpeechPadMs = freezed,}) {
   return _then(_TranscribeRequestDto(
 audio: null == audio ? _self.audio : audio // ignore: cast_nullable_to_non_nullable
 as String,model: null == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
@@ -325,7 +333,9 @@ as String?,noContext: null == noContext ? _self.noContext : noContext // ignore:
 as bool,suppressNonSpeechTokens: null == suppressNonSpeechTokens ? _self.suppressNonSpeechTokens : suppressNonSpeechTokens // ignore: cast_nullable_to_non_nullable
 as bool,progressCallback: freezed == progressCallback ? _self.progressCallback : progressCallback // ignore: cast_nullable_to_non_nullable
 as int?,keepModelLoaded: null == keepModelLoaded ? _self.keepModelLoaded : keepModelLoaded // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,vadModel: freezed == vadModel ? _self.vadModel : vadModel // ignore: cast_nullable_to_non_nullable
+as String?,vadSpeechPadMs: freezed == vadSpeechPadMs ? _self.vadSpeechPadMs : vadSpeechPadMs // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 

--- a/lib/src/models/requests/transcribe_request_dto.g.dart
+++ b/lib/src/models/requests/transcribe_request_dto.g.dart
@@ -28,6 +28,8 @@ _TranscribeRequestDto _$TranscribeRequestDtoFromJson(
   suppressNonSpeechTokens: json['suppress_non_speech_tokens'] as bool? ?? false,
   progressCallback: (json['progress_callback'] as num?)?.toInt(),
   keepModelLoaded: json['keep_model_loaded'] as bool? ?? false,
+  vadModel: json['vad_model'] as String?,
+  vadSpeechPadMs: (json['vad_speech_pad_ms'] as num?)?.toInt(),
 );
 
 Map<String, dynamic> _$TranscribeRequestDtoToJson(
@@ -52,4 +54,6 @@ Map<String, dynamic> _$TranscribeRequestDtoToJson(
   'suppress_non_speech_tokens': instance.suppressNonSpeechTokens,
   'progress_callback': instance.progressCallback,
   'keep_model_loaded': instance.keepModelLoaded,
+  'vad_model': instance.vadModel,
+  'vad_speech_pad_ms': instance.vadSpeechPadMs,
 };

--- a/macos/Classes/whisper_ggml.cpp
+++ b/macos/Classes/whisper_ggml.cpp
@@ -147,6 +147,13 @@ struct whisper_params
     // Address of a Dart NativeCallable<Void Function(Int32)>; 0 = none.
     uint64_t progress_cb_addr = 0;
 
+    // Silero VAD (whisper.cpp built-in): trims non-speech before decoding,
+    // which stops whisper hallucinating or looping over leading/trailing
+    // silence in push-to-talk recordings. Empty = VAD off (default).
+    std::string vad_model;
+    // speech_pad_ms override; negative keeps whisper.cpp's default.
+    int32_t vad_speech_pad_ms = -1;
+
     std::string language = "id";
     std::string prompt;
     std::string model = "models/ggml-model-whisper-small.bin";
@@ -193,6 +200,14 @@ json transcribe(json jsonBody)
     if (jsonBody.contains("progress_callback") && jsonBody["progress_callback"].is_number_unsigned())
     {
         params.progress_cb_addr = jsonBody["progress_callback"].get<uint64_t>();
+    }
+    if (jsonBody.contains("vad_model") && jsonBody["vad_model"].is_string())
+    {
+        params.vad_model = jsonBody["vad_model"].get<std::string>();
+    }
+    if (jsonBody.contains("vad_speech_pad_ms") && jsonBody["vad_speech_pad_ms"].is_number_integer())
+    {
+        params.vad_speech_pad_ms = jsonBody["vad_speech_pad_ms"].get<int32_t>();
     }
     json jsonResult;
     jsonResult["@type"] = "transcribe";
@@ -336,6 +351,17 @@ json transcribe(json jsonBody)
         }
         wparams.no_context = params.no_context;
         wparams.suppress_nst = params.suppress_nst;
+
+        // params.vad_model outlives whisper_full(), so the pointer stays
+        // valid for the whole decode.
+        if (!params.vad_model.empty()) {
+            wparams.vad = true;
+            wparams.vad_model_path = params.vad_model.c_str();
+            wparams.vad_params = whisper_vad_default_params();
+            if (params.vad_speech_pad_ms >= 0) {
+                wparams.vad_params.speech_pad_ms = params.vad_speech_pad_ms;
+            }
+        }
 
         if (params.split_on_word) {
             wparams.max_len = 1;

--- a/test/transcribe_request_dto_test.dart
+++ b/test/transcribe_request_dto_test.dart
@@ -118,5 +118,39 @@ void main() {
       final body = json.decode(dto.toRequestString()) as Map<String, dynamic>;
       expect(body['keep_model_loaded'], isTrue);
     });
+
+    test('VAD stays off by default and forwards model path and padding', () {
+      final defaultDto = TranscribeRequestDto.fromTranscribeRequest(
+        request(),
+        '/tmp/model.bin',
+      );
+      final defaultBody =
+          json.decode(defaultDto.toRequestString()) as Map<String, dynamic>;
+      // Null on the wire: the native side only enables VAD for a string.
+      expect(defaultBody['vad_model'], isNull);
+      expect(defaultBody['vad_speech_pad_ms'], isNull);
+
+      final dto = TranscribeRequestDto.fromTranscribeRequest(
+        const TranscribeRequest(
+          audio: '/tmp/audio.wav',
+          vadModelPath: '/tmp/ggml-silero-v5.1.2.bin',
+          vadSpeechPadMs: 100,
+        ),
+        '/tmp/model.bin',
+      );
+      final body = json.decode(dto.toRequestString()) as Map<String, dynamic>;
+      expect(body['vad_model'], '/tmp/ggml-silero-v5.1.2.bin');
+      expect(body['vad_speech_pad_ms'], 100);
+    });
+
+    test('a VAD padding override without a model path stays inert', () {
+      final dto = TranscribeRequestDto.fromTranscribeRequest(
+        const TranscribeRequest(audio: '/tmp/audio.wav', vadSpeechPadMs: 250),
+        '/tmp/model.bin',
+      );
+      final body = json.decode(dto.toRequestString()) as Map<String, dynamic>;
+      expect(body['vad_model'], isNull);
+      expect(body['vad_speech_pad_ms'], 250);
+    });
   });
 }


### PR DESCRIPTION
Fixes #29. Follow-up to #26 / #27, as invited in the 2.6.0 closing comment — the VAD half, rebased fresh on current master.

## What it does

`TranscribeRequest` gains `vadModelPath` and `vadSpeechPadMs`. When a Silero VAD model path is set, the native layer enables whisper.cpp's built-in VAD for that request (`wparams.vad` + `vad_model_path`), trimming non-speech before decoding — the standard defence against whisper hallucinating or looping over the leading/trailing silence of push-to-talk recordings. `vadSpeechPadMs` optionally overrides `vad_params.speech_pad_ms` so clipped first words stay intact (~100 ms works well for dictation); unset or negative keeps whisper.cpp's default.

## Scope and safety

- **Off by default** — without `vadModelPath` the request JSON carries `null`, the shim's `is_string()` guard leaves VAD disabled, and behavior is byte-identical to 2.6.0.
- **No shared state, no locking changes** — VAD runs inside `whisper_full` on the requesting context only, composing cleanly with the 2.6.0 resident-model checkout.
- **All three native shims** carry the identical block — `android/src/whisper/main.cpp` (also compiled by the Windows and Linux CMake builds), `ios/Classes/whisper_flutter_plus.cpp`, and `macos/Classes/whisper_ggml.cpp`. The two Apple shims were clang syntax/type-checked against their own vendored headers (both vendor a VAD-capable whisper.cpp).
- Generated files were rebuilt with the toolchain matching the committed outputs, so the diff contains only the new fields.

## Verification

Three new DTO serialization tests (suite 15/15 green): off-by-default, both fields forwarded, and a pad override without a model path staying inert. Exercised end-to-end on Windows release builds through our dictation app's benchmark corpus — Hindi/Hinglish/Tamil Whisper fine-tunes, 3/3 identical transcripts per language, composing with `keepModelLoaded` (warm prepares ~200–300 ms). In production use these same fine-tunes reliably looped over hold-to-talk silence without VAD trimming; with it they have been clean across thousands of dictations.

## Noticed while porting (separate from this PR)

The macOS shim predates 2.6.0's resident-model support — `macos/Classes/whisper_ggml.cpp` has no `keep_model_loaded`/`releaseModel` handling, so macOS callers currently reload the model per request. This branch deliberately does not mix that fix in; happy to file it as an issue (or a follow-up PR) if useful.
